### PR TITLE
fix: #18 CI build error 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,13 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      - name: Install dependencies
-        run: pnpm install
-
       - name: create .env
         run: |
+          touch .env
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Debug prisma
+        run: |
+          echo "Checking Prisma CLI version:"
+          pnpm prisma --version
+          echo "Checking if .env exists:"
+          ls -la .env || echo ".env not found"
+          echo "Checking generated client:"
+          ls -la node_modules/.prisma/client/ || echo "Client not generated"
+
       - name: Run lint
         run: pnpm lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
 
-      - name: Prisma set
-        run: pnpm prisma generate
-
       - name: Run lint
         run: pnpm lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: create .env
+        run: |
+          echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+
+      - name: Prisma set
+        run: npx prisma generate
+
       - name: Run lint
         run: pnpm lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
 
       - name: Prisma set
-        run: npx prisma generate
+        run: pnpm prisma generate
 
       - name: Run lint
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "prisma generate && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "prisma generate && next build",
+    "prebuild": "prisma generate",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## 🔍 개요 (Overview)

PR 시 CI build error 해결하기 위한 시도


## ✅ 작업 사항 (Work Done)

- [x] package.json script prebuild: "prisma generate", build: "next build"로 수정
- [x] ci.yml 파일에서 prisma 관련 스텝 제거(스크립트와 중복이라서)
- [x] github repository setting에 env 변수 추가
- [x] ci.yml 파일에 env 변수 사용할 수 있도록 추가
- [x] prisma/schema.prisma 파일에서 prisma client의 output 경로 제거(default로)

##  reviewers에게

이 문제가 발생한 이유를 찾아 정리한 것을 공유 드립니다!

### 커스텀 output path의 문제 이유
1. pnpm의 엄격한 의존성 해결
pnpm은 npm과 달리 매우 엄격한 의존성 해결을 사용해서 
커스텀 output 경로가 `../node_modules/@prisma/xxx-client` 같이 설정되어 있을 때
pnpm에서 '.prisma/client/default' 모듈을 찾을 수 없다는 에러 [참고 블로그](https://www.sinclair.software/articles/pnpm-prisma-generation-issue/)가 발생한다.

2. 경로 해결의 복잡성
GitHub Actions 환경에서는:
- 로컬 개발환경과 파일 시스템 구조가 다를 수 있음
- pnpm의 symlink 구조가 복잡함
- custom output 경로가 상대 경로일 때 해석이 달라질 수 있음

3. 패키지 번들링 문제
custom output 위치에서는 package.json이 생성되지 않아 번들링이 제대로 작동하지 않는 문제도 있을 수 있다고 함

### 결론
저희가 작성했던 output = "../node_modules/.prisma/client"는 기본 경로와 같아 보이지만,
- 상대 경로 해석의 차이
- pnpm의 엄격한 모듈 해결 방식
- CI 환경에서의 파일 시스템 구조 차이
때문에 문제가 발생했던 것이었다!
허무하게 해결. 하지만 행복