### PR TITLE
[GET] 월별 사용자 로그 조회 API 구현

### DIFF
--- a/app/api/user/logs/route.ts
+++ b/app/api/user/logs/route.ts
@@ -5,6 +5,48 @@ import { PrWorkoutRepository } from "../../../../backend/infrastructure/reposito
 import { PrLogWorkoutRepository } from "../../../../backend/infrastructure/repositories/PrLogWorkoutRepository"
 import { PrBodyPartGaugeRepository } from "../../../../backend/infrastructure/repositories/PrBodyPartGaugeRepository"
 import { CreateLogRequestDto } from "../../../../backend/application/user/logs/dtos/CreateLogRequestDto"
+import { GetUserLogsQueryDto } from "@/backend/application/user/logs/dtos/GetUserLogsQueryDto"
+import { GetUserLogsRequestDto } from "@/backend/application/user/logs/dtos/GetUserLogsRequestDto"
+import { GetUserLogListUsecase } from "@/backend/application/user/logs/usecases/GetUserLogListUsecase"
+
+export async function GET(req: NextRequest) {
+  const { userId }: GetUserLogsRequestDto = await req.json()
+  const { searchParams } = new URL(req.url)
+  const year = Number(searchParams.get("year"))
+  const month = Number(searchParams.get("month"))
+
+  if (!year || !month) {
+    return NextResponse.json({ message: "error" }, { status: 400 })
+  }
+
+  if (!userId) {
+    return NextResponse.json({ message: "error" }, { status: 400 })
+  }
+
+  const usecase = new GetUserLogListUsecase(new PrLogRepository())
+  const requestDto: GetUserLogsRequestDto = { userId }
+  const queryDto: GetUserLogsQueryDto = { year, month }
+
+  if (isNaN(queryDto.year) || isNaN(queryDto.month)) {
+    return NextResponse.json({ message: "error" }, { status: 400 })
+  }
+
+  try {
+    const result = await usecase.execute(requestDto, queryDto)
+
+    if (result.success) {
+      return NextResponse.json(
+        { message: "success", logs: result.logs },
+        { status: 200 }
+      )
+    } else {
+      return NextResponse.json({ message: "error" }, { status: 400 })
+    }
+  } catch (error) {
+    console.log(error instanceof Error ? error.message : "Failed to fetch logs")
+    return NextResponse.json({ message: "error" }, { status: 500 })
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,7 +61,7 @@ export async function POST(request: NextRequest) {
       logRepository,
       workoutRepository,
       logWorkoutRepository,
-      bodyPartGaugeRepository,
+      bodyPartGaugeRepository
     )
 
     const result = await createLogUsecase.execute(body)
@@ -33,7 +75,7 @@ export async function POST(request: NextRequest) {
         success: false,
         message: error instanceof Error ? error.message : "log creation failed",
       },
-      { status: 500 },
+      { status: 500 }
     )
   }
 }

--- a/backend/application/user/logs/dtos/GetLogDto.ts
+++ b/backend/application/user/logs/dtos/GetLogDto.ts
@@ -1,0 +1,11 @@
+import { WorkoutDto } from "./GetWorkoutDto"
+
+export interface LogDto {
+  id: number
+  calIconType: string
+  createdAt: string
+  totalDuration: number
+
+  // Relations
+  workouts: WorkoutDto[]
+}

--- a/backend/application/user/logs/dtos/GetUserLogsQueryDto.ts
+++ b/backend/application/user/logs/dtos/GetUserLogsQueryDto.ts
@@ -1,0 +1,4 @@
+export interface GetUserLogsQueryDto {
+  year: number
+  month: number
+}

--- a/backend/application/user/logs/dtos/GetUserLogsRequestDto.ts
+++ b/backend/application/user/logs/dtos/GetUserLogsRequestDto.ts
@@ -1,0 +1,3 @@
+export interface GetUserLogsRequestDto {
+  userId: string
+}

--- a/backend/application/user/logs/dtos/GetUserLogsResponseDto.ts
+++ b/backend/application/user/logs/dtos/GetUserLogsResponseDto.ts
@@ -1,0 +1,7 @@
+import { LogDto } from "./GetLogDto"
+
+export interface GetUserLogsResponseDto {
+  success: boolean
+  message: string
+  logs: LogDto[]
+}

--- a/backend/application/user/logs/dtos/GetWorkoutDto.ts
+++ b/backend/application/user/logs/dtos/GetWorkoutDto.ts
@@ -1,0 +1,10 @@
+export interface WorkoutDto {
+  id: number
+  seq: number
+  exerciseName: string
+  setCount: number
+  weight?: number
+  repetitionCount?: number
+  distance?: number
+  durationSeconds?: number
+}

--- a/backend/application/user/logs/usecases/GetUserLogListUsecase.ts
+++ b/backend/application/user/logs/usecases/GetUserLogListUsecase.ts
@@ -1,0 +1,62 @@
+import { Log } from "@/backend/domain/entities/Log"
+import { LogWorkout } from "@/backend/domain/entities/LogWorkout"
+import { LogRepository } from "../../../../domain/repositories/LogRepository"
+import { LogDto } from "../dtos/GetLogDto"
+import { GetUserLogsQueryDto } from "../dtos/GetUserLogsQueryDto"
+import { GetUserLogsRequestDto } from "../dtos/GetUserLogsRequestDto"
+import { GetUserLogsResponseDto } from "../dtos/GetUserLogsResponseDto"
+import { WorkoutDto } from "../dtos/GetWorkoutDto"
+
+export class GetUserLogListUsecase {
+  constructor(private readonly logRepository: LogRepository) {}
+
+  async execute(
+    request: GetUserLogsRequestDto,
+    query: GetUserLogsQueryDto
+  ): Promise<GetUserLogsResponseDto> {
+    const logs = await this.logRepository.findAllByUserIdAndMonth(
+      request.userId,
+      query.year,
+      query.month
+    )
+
+    const logDtos: LogDto[] = logs.map((log) => ({
+      id: log.id,
+      calIconType: log.calIconType,
+      createdAt: log.createdAt.toISOString(),
+      totalDuration: log.totalDuration,
+      workouts: this.mapWorkouts(log),
+    }))
+
+    return {
+      success: true,
+      message: "로그 목록을 성공적으로 조회했습니다.",
+      logs: logDtos
+    }
+  }
+
+  private mapWorkouts(log: Log): WorkoutDto[] {
+    if (!log.logWorkouts) return []
+
+    const workouts = log.logWorkouts.map((logWorkout: LogWorkout) => ({
+      id: logWorkout.workout!.id,
+      seq: logWorkout.workout!.seq,
+      exerciseName: logWorkout.workout!.exerciseName,
+      setCount: logWorkout.workout!.setCount,
+      weight: logWorkout.workout!.weight,
+      repetitionCount: logWorkout.workout!.repetitionCount,
+      distance: logWorkout.workout!.distance,
+      durationSeconds: logWorkout.workout!.durationSeconds,
+    }))
+
+    // seq 우선, seq가 같으면 setCount로 정렬
+    workouts.sort((a, b) => {
+      if (a.seq !== b.seq) {
+        return a.seq - b.seq
+      }
+      return a.setCount - b.setCount
+    })
+
+    return workouts;
+  }
+}

--- a/backend/domain/entities/Log.ts
+++ b/backend/domain/entities/Log.ts
@@ -1,7 +1,9 @@
+import { LogWorkout } from "./LogWorkout"
+
 export enum CalIconType {
   CARDIO = "cardio",
   UPPER = "upper",
-  LOWER = "lower"
+  LOWER = "lower",
 }
 
 export class Log {
@@ -10,6 +12,9 @@ export class Log {
     public readonly userId: string,
     public readonly calIconType: CalIconType,
     public readonly totalDuration: number,
-    public readonly createdAt: Date = new Date()
+    public readonly createdAt: Date = new Date(),
+
+    // Relations
+    public readonly logWorkouts?: LogWorkout[]
   ) {}
 }

--- a/backend/domain/entities/LogWorkout.ts
+++ b/backend/domain/entities/LogWorkout.ts
@@ -1,7 +1,12 @@
+import { Log } from "./Log"
+import { Workout } from "./Workout"
+
 export class LogWorkout {
   constructor(
     public readonly id: number,
     public readonly logId: number,
-    public readonly workoutId: number
+    public readonly workoutId: number,
+    public readonly log?: Log,
+    public readonly workout?: Workout
   ) {}
 }

--- a/backend/domain/entities/Workout.ts
+++ b/backend/domain/entities/Workout.ts
@@ -1,3 +1,6 @@
+import { Log } from "./Log"
+import { LogWorkout } from "./LogWorkout"
+
 export class Workout {
   constructor(
     public readonly id: number,
@@ -7,6 +10,8 @@ export class Workout {
     public readonly weight?: number,
     public readonly repetitionCount?: number,
     public readonly distance?: number,
-    public readonly durationSeconds?: number
+    public readonly durationSeconds?: number,
+    public readonly logWorkouts?: LogWorkout[], // 1:N
+    public readonly logs?: Log[] // N:M (간접)
   ) {}
 }

--- a/backend/domain/repositories/LogRepository.ts
+++ b/backend/domain/repositories/LogRepository.ts
@@ -1,9 +1,14 @@
-import { Log } from "../entities/Log";
+import { Log } from "../entities/Log"
 
 export interface LogRepository {
-  findAll(): Promise<Log[]>;
-  findById(id: number): Promise<Log | null>;
-  save(log: Log): Promise<Log>;
-  update(id: number, log: Partial<Log>): Promise<Log | null>;
-  delete(id: number): Promise<boolean>;
+  findAll(): Promise<Log[]>
+  findAllByUserIdAndMonth(
+    userId: string,
+    year: number,
+    month: number
+  ): Promise<Log[]>
+  findById(id: number): Promise<Log | null>
+  save(log: Log): Promise<Log>
+  update(id: number, log: Partial<Log>): Promise<Log | null>
+  delete(id: number): Promise<boolean>
 }


### PR DESCRIPTION
## 🔍 개요 (Overview)
월별 사용자 로그 및 연결된 Workout 목록 데이터 조회
This closes #7 


## ✅ 작업 사항 (Work Done)

- [x] `GET /api/user/logs?year=YYYY&month=MM` 엔드포인트 추가
- [x] `Log`, `LogWorkout`, `Workout` 엔티티에 Log-Workout m:n 관계 매핑 관련 추가
- [x] 관련 DTO 파일 생성
- [x] GetUserLogListUsecase 작성
- [x] LogRepository.findAllByUserIdAndMonth 메서드 추가


## 📸 스크린샷 (Screenshots)

##  reviewers에게