### PR TITLE
[GET] 추가된 컬럼 구조에 맞춰 운동 기록 조회 API 수정 및 repository 기간별 조회 메서드 통합

### DIFF
--- a/backend/application/user/logs/dtos/GetLogDto.ts
+++ b/backend/application/user/logs/dtos/GetLogDto.ts
@@ -1,10 +1,20 @@
-import { WorkoutDto } from "./GetWorkoutDto"
+import { WorkoutDto } from "@/backend/application/user/logs/dtos/GetWorkoutDto"
+
+export enum CalIconType {
+  CARDIO = "cardio",
+  UPPER = "upper",
+  LOWER = "lower",
+}
+
+export type BodyPartsGroup = "legs" | "back" | "chest" | "shoulders" | "arms" | "core" | "stamina"
 
 export interface LogDto {
   id: number
-  calIconType: string
-  createdAt: string
+  userId: string
+  calIconType: CalIconType
+  createdAt: Date
   totalDuration: number
+  gaugeChanges: Record<BodyPartsGroup, number>
 
   // Relations
   workouts: WorkoutDto[]

--- a/backend/application/user/logs/dtos/GetUserLogsResponseDto.ts
+++ b/backend/application/user/logs/dtos/GetUserLogsResponseDto.ts
@@ -1,4 +1,4 @@
-import { LogDto } from "./GetLogDto"
+import { LogDto } from "@/backend/application/user/logs/dtos/GetLogDto"
 
 export interface GetUserLogsResponseDto {
   success: boolean

--- a/backend/application/user/logs/usecases/GetUserLogListUsecase.ts
+++ b/backend/application/user/logs/usecases/GetUserLogListUsecase.ts
@@ -14,10 +14,14 @@ export class GetUserLogListUsecase {
     request: GetUserLogsRequestDto,
     query: GetUserLogsQueryDto
   ): Promise<GetUserLogsResponseDto> {
-    const logs = await this.logRepository.findAllByUserIdAndMonth(
+    const startDate = new Date(query.year, query.month - 1, 1)
+    const endDate = new Date(query.year, query.month, 0, 23, 59, 59, 999)
+    
+    const logs = await this.logRepository.findAllByUserIdAndDateRange(
       request.userId,
-      query.year,
-      query.month
+      startDate,
+      endDate,
+      true
     )
 
     const logDtos: LogDto[] = logs.map((log) => ({

--- a/backend/application/user/logs/usecases/GetUserLogListUsecase.ts
+++ b/backend/application/user/logs/usecases/GetUserLogListUsecase.ts
@@ -1,11 +1,11 @@
 import { Log } from "@/backend/domain/entities/Log"
 import { LogWorkout } from "@/backend/domain/entities/LogWorkout"
-import { LogRepository } from "../../../../domain/repositories/LogRepository"
-import { LogDto } from "../dtos/GetLogDto"
-import { GetUserLogsQueryDto } from "../dtos/GetUserLogsQueryDto"
-import { GetUserLogsRequestDto } from "../dtos/GetUserLogsRequestDto"
-import { GetUserLogsResponseDto } from "../dtos/GetUserLogsResponseDto"
-import { WorkoutDto } from "../dtos/GetWorkoutDto"
+import { LogRepository } from "@/backend/domain/repositories/LogRepository"
+import { LogDto } from "@/backend/application/user/logs/dtos/GetLogDto"
+import { GetUserLogsQueryDto } from "@/backend/application/user/logs/dtos/GetUserLogsQueryDto"
+import { GetUserLogsRequestDto } from "@/backend/application/user/logs/dtos/GetUserLogsRequestDto"
+import { GetUserLogsResponseDto } from "@/backend/application/user/logs/dtos/GetUserLogsResponseDto"
+import { WorkoutDto } from "@/backend/application/user/logs/dtos/GetWorkoutDto"
 
 export class GetUserLogListUsecase {
   constructor(private readonly logRepository: LogRepository) {}
@@ -22,9 +22,11 @@ export class GetUserLogListUsecase {
 
     const logDtos: LogDto[] = logs.map((log) => ({
       id: log.id,
+      userId: log.userId,
       calIconType: log.calIconType,
-      createdAt: log.createdAt.toISOString(),
+      createdAt: log.createdAt,
       totalDuration: log.totalDuration,
+      gaugeChanges: log.gaugeChanges,
       workouts: this.mapWorkouts(log),
     }))
 

--- a/backend/domain/repositories/LogRepository.ts
+++ b/backend/domain/repositories/LogRepository.ts
@@ -1,16 +1,12 @@
-import { Log } from "../entities/Log"
+import { Log } from "@/backend/domain/entities/Log"
 
 export interface LogRepository {
   findAll(): Promise<Log[]>
-  findAllByUserIdAndMonth(
-    userId: string,
-    year: number,
-    month: number
-  ): Promise<Log[]>
-  findByUserIdAndDateRange(
+  findAllByUserIdAndDateRange(
     userId: string,
     startDate: Date,
-    endDate: Date
+    endDate: Date,
+    includeWorkouts?: boolean
   ): Promise<Log[]>
   findById(id: number): Promise<Log | null>
   save(log: Log): Promise<Log>

--- a/backend/infrastructure/repositories/PrLogRepository.ts
+++ b/backend/infrastructure/repositories/PrLogRepository.ts
@@ -8,41 +8,11 @@ export class PrLogRepository implements LogRepository {
     return logs.map(this.toDomain)
   }
 
-  async findAllByUserIdAndMonth(
-    userId: string,
-    year: number,
-    month: number
-  ): Promise<Log[]> {
-    const startDate = new Date(year, month - 1, 1)
-    const endDate = new Date(year, month, 1)
-
-    const logs = await prisma.log.findMany({
-      where: {
-        userId,
-        createdAt: {
-          gte: startDate,
-          lt: endDate,
-        },
-      },
-      include: {
-        logWorkouts: {
-          include: {
-            workout: true,
-          },
-        },
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    })
-
-    return logs as Log[]
-  }
-
-  async findByUserIdAndDateRange(
+  async findAllByUserIdAndDateRange(
     userId: string,
     startDate: Date,
-    endDate: Date
+    endDate: Date,
+    includeWorkouts: boolean = false
   ): Promise<Log[]> {
     const logs = await prisma.log.findMany({
       where: {
@@ -52,6 +22,15 @@ export class PrLogRepository implements LogRepository {
           lte: endDate,
         },
       },
+      ...(includeWorkouts && {
+        include: {
+          logWorkouts: {
+            include: {
+              workout: true,
+            },
+          },
+        },
+      }),
       orderBy: {
         createdAt: "desc",
       },


### PR DESCRIPTION
## 🔍 개요 (Overview)

이 PR은 어떤 변경사항을 담고 있나요? 관련 이슈가 있다면 연결해주세요.
- `logs` 테이블에 추가된 `gaugeChanges` 컬럼에 맞추어 DTO 수정
- 뱃지 추가 로직 시 추가 생성된 repository 기간별 조회 메서드를 기존 월별 조회 메서드와 통합


This closes #74 


## ✅ 작업 사항 (Work Done)

- [x] `logs` 테이블에 추가된 `gaugeChanges` 컬럼에 맞추어 DTO 수정
- [x] import 절대경로로 수정
- [x] `findAllByUserIdAndMonth` 와 `findByUserIdAndDateRange` 를 하나로 통합
- [x] GetUserLogListUsecase.ts에 변경 사항 적용

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|        |       |


##  reviewers에게
