### PR TITLE
[헤더] 공통 헤더 추가

### DIFF
--- a/app/components/ConditionHeader.tsx
+++ b/app/components/ConditionHeader.tsx
@@ -1,0 +1,11 @@
+"use client"
+import { Header } from "@/ds/components/molecules/header/Header"
+import { usePathname } from "next/navigation"
+
+const ConditionHeader = () => {
+  const pathname = usePathname()
+  if (pathname === "/" || pathname === "/landing") return
+  return <Header className="fixed top-0" />
+}
+
+export default ConditionHeader

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import ToastContainer from "./components/ToastContainer"
 import DialogContainer from "./components/DialogContainer"
 import NextAuthSessionProviders from "./providers/NextAuthSessionProviders"
 import ReactQueryProvider from "./providers/ReactQueryProvider"
+import ConditionHeader from "./components/ConditionHeader"
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -26,6 +27,7 @@ export default async function RootLayout({
         <div
           className={`relative box-border flex min-h-screen w-full max-w-[430px] flex-col items-center !bg-[var(--color-white-200)] px-[30px] pt-[100px] pb-[70px]`}
         >
+          <ConditionHeader />
           <NextAuthSessionProviders session={session}>
             <ReactQueryProvider>{children}</ReactQueryProvider>
             <ToastContainer />

--- a/ds/components/molecules/header/Header.tsx
+++ b/ds/components/molecules/header/Header.tsx
@@ -1,14 +1,22 @@
+"use client"
 import React from "react"
 import Image from "next/image"
 import { HeaderProps } from "./Header.types"
 import { Button } from "../../atoms/button/Button"
 import Icon from "../../atoms/icon/Icon"
+import { useRouter } from "next/navigation"
 
 export const Header: React.FC<HeaderProps> = ({
   showBackButton = true,
   className,
   onBack,
 }) => {
+  const router = useRouter()
+  const onClickBack = () => {
+    if (onBack) onBack()
+
+    router.back()
+  }
   return (
     <header
       className={`flex h-15 w-full items-center bg-[var(--color-white-200)] p-2.5 ${className}`}
@@ -16,7 +24,7 @@ export const Header: React.FC<HeaderProps> = ({
       {/* 왼쪽: 뒤로가기 */}
       <div className="flex items-center">
         {showBackButton && (
-          <Button size="xs" variant="ghost" onClick={onBack}>
+          <Button size="xs" variant="ghost" onClick={onClickBack}>
             <Icon name="leftArrow" size={30} fillColor="primary" />
           </Button>
         )}


### PR DESCRIPTION
- 메인페이지와 랜딩페이지인 경우는 헤더 보이지 않도록 함

## 🔍 개요 (Overview)

공통 layout에 헤더 추가
(Closes #108 )


## ✅ 작업 사항 (Work Done)

- [x] 헤더 컴포넌트에서 back 버튼 클릭 시 navigation 처리 추가
- [x] `/`, `/landing`페이지에서는 헤더가 보이지 않도록 조건 추가


## 📸 스크린샷 (Screenshots)


##  reviewers에게

