### PR TITLE
[디자인시스템] header 컴포넌트 max-width `inherit` 적용

### DIFF
--- a/ds/components/molecules/header/Header.tsx
+++ b/ds/components/molecules/header/Header.tsx
@@ -19,7 +19,7 @@ export const Header: React.FC<HeaderProps> = ({
   }
   return (
     <header
-      className={`flex h-15 w-full items-center bg-[var(--color-white-200)] p-2.5 ${className}`}
+      className={`flex h-15 max-w-[inherit] w-full items-center bg-[var(--color-white-200)] p-2.5 ${className}`}
     >
       {/* 왼쪽: 뒤로가기 */}
       <div className="flex items-center">

--- a/ds/components/molecules/header/Header.tsx
+++ b/ds/components/molecules/header/Header.tsx
@@ -19,7 +19,7 @@ export const Header: React.FC<HeaderProps> = ({
   }
   return (
     <header
-      className={`flex h-15 max-w-[inherit] w-full items-center bg-[var(--color-white-200)] p-2.5 ${className}`}
+      className={`flex h-15 max-w-[inherit] w-full items-center bg-[var(--color-white-200)] z-100 p-2.5 ${className}`}
     >
       {/* 왼쪽: 뒤로가기 */}
       <div className="flex items-center">


### PR DESCRIPTION
## 🔍 개요 (Overview)
header 가 상위 태그의 max-width 넘는 이슈 해결

This closes #121 


## ✅ 작업 사항 (Work Done)

- [x] header 컴포넌트 max-width `inherit` 적용


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
| <img width="730" height="436" alt="image" src="https://github.com/user-attachments/assets/2cf5281a-29a5-4bf8-b0a1-0fb8163a865c" /> |  <img width="730" height="436" alt="image" src="https://github.com/user-attachments/assets/5973a811-6e5b-4168-a754-8f59830f9ca3" />  |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
