### PR TITLE
로그인 페이지 컴포넌트 분리 및 레이아웃 수정

### DIFF
--- a/app/signin/components/SigninForm.tsx
+++ b/app/signin/components/SigninForm.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useSignin } from "@/hooks/useSignin"
+import { useState } from "react"
+import Title from "../../components/title/Title"
+import { Input } from "@/ds/components/atoms/input/Input"
+import { Button } from "@/ds/components/atoms/button/Button"
+import { S1 } from "@/ds/components/atoms/text/TextWrapper"
+
+const SigninForm = () => {
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const { signin } = useSignin()
+
+  const isFormValid = email.trim() !== "" && password.trim() !== ""
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await signin(email, password)
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col gap-10">
+      <Title title="로그인" subTitle="잇근과 함께 득근하세요!" />
+      <form
+        className="flex h-full flex-col justify-between"
+        onSubmit={handleSubmit}
+      >
+        <div className="flex flex-col gap-10">
+          <Input
+            placeholder="email"
+            size="lg"
+            isFullWidth={true}
+            value={email}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setEmail(e.target.value)
+            }
+            className="border-b-2"
+          />
+          <Input
+            type="password"
+            placeholder="password"
+            size="lg"
+            isFullWidth={true}
+            value={password}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setPassword(e.target.value)
+            }
+            className="border-b-2"
+          />
+        </div>
+        <div className="-mx-3 py-2.5">
+          <Button
+            variant={isFormValid ? "primary" : "disable"}
+            isFullWidth={true}
+            type="submit"
+          >
+            <S1 variant="white-200">로그인</S1>
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default SigninForm

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,68 +1,7 @@
-"use client"
-
-import { useState } from "react"
-import { Button } from "@/ds/components/atoms/button/Button"
-import { Input } from "@/ds/components/atoms/input/Input"
-import { C1, H1, S1 } from "@/ds/components/atoms/text/TextWrapper"
-import { useSignin } from "@/hooks/useSignin"
+import SigninForm from "./components/SigninForm"
 
 const SignInPage = () => {
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const { signin } = useSignin()
-
-  const isFormValid = email.trim() !== "" && password.trim() !== ""
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    await signin(email, password)
-  }
-
-  return (
-    <form
-      className="flex min-h-screen flex-col justify-between pt-10"
-      onSubmit={handleSubmit}
-    >
-      <div className="flex flex-col gap-10 px-7.5">
-        <div className="flex flex-col gap-2.5">
-          <H1>로그인</H1>
-          <C1 variant="secondary">잇근과 함께 득근하세요!</C1>
-        </div>
-        <div className="flex flex-col gap-10">
-          <Input
-            placeholder="email"
-            size="lg"
-            isFullWidth={true}
-            value={email}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setEmail(e.target.value)
-            }
-            className="border-b-2"
-          />
-          <Input
-            type="password"
-            placeholder="password"
-            size="lg"
-            isFullWidth={true}
-            value={password}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setPassword(e.target.value)
-            }
-            className="border-b-2"
-          />
-        </div>
-      </div>
-      <div className="px-3.5 py-2.5">
-        <Button
-          variant={isFormValid ? "primary" : "disable"}
-          isFullWidth={true}
-          type="submit"
-        >
-          <S1 variant="white-200">로그인</S1>
-        </Button>
-      </div>
-    </form>
-  )
+  return <SigninForm />
 }
 
 export default SignInPage


### PR DESCRIPTION
## 🔍 개요 (Overview)
로그인(/signin) 페이지 컴포넌트 분리 및 레이아웃 수정
Closes #104 


## ✅ 작업 사항 (Work Done)
- [x] 로그인 페이지 컴포넌트 분리
- [x] style 수정


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/51053ee7-a7c0-40e1-8851-70ef7002ddf6" />| <img width="300" alt="image" src="https://github.com/user-attachments/assets/f78d721c-e99c-472d-bbfb-d794fe506e58" /> |


##  reviewers에게
