### PR TITLE
[QA] 특정 날짜의 캐릭터 조회 시 오류 해결

### DIFF
--- a/backend/infrastructure/repositories/PrBodyPartGaugeRepository.ts
+++ b/backend/infrastructure/repositories/PrBodyPartGaugeRepository.ts
@@ -10,7 +10,10 @@ export class PrBodyPartGaugeRepository implements BodyPartGaugeRepository {
     return gauges.map(this.toDomain)
   }
 
-  async findById(id: number, tx?: TransactionClient): Promise<BodyPartGauge | null> {
+  async findById(
+    id: number,
+    tx?: TransactionClient
+  ): Promise<BodyPartGauge | null> {
     const client = tx || prisma
     const gauge = await client.bodyPartGauge.findUnique({
       where: { id },
@@ -18,7 +21,11 @@ export class PrBodyPartGaugeRepository implements BodyPartGaugeRepository {
     return gauge ? this.toDomain(gauge) : null
   }
 
-  async findByUserId(id: string, date?: Date, tx?: TransactionClient): Promise<BodyPartGauge | null> {
+  async findByUserId(
+    id: string,
+    date?: Date,
+    tx?: TransactionClient
+  ): Promise<BodyPartGauge | null> {
     const whereCondition: any = { userId: id }
 
     if (date) {
@@ -26,23 +33,34 @@ export class PrBodyPartGaugeRepository implements BodyPartGaugeRepository {
     }
 
     const client = tx || prisma
-    const userBodyPartGauge = await client.bodyPartGauge.findUnique({
+    const userBodyPartGauge = await client.bodyPartGauge.findFirst({
       where: whereCondition,
+      orderBy: {
+        earnedAt: "desc",
+      },
     })
 
-    return userBodyPartGauge as BodyPartGauge || null
+    console.log("userBodyPartGauge", userBodyPartGauge)
+
+    return (userBodyPartGauge as BodyPartGauge) || null
   }
 
-  async findLatestOneByUserId(userId: string, tx?: TransactionClient): Promise<BodyPartGauge | null> {
+  async findLatestOneByUserId(
+    userId: string,
+    tx?: TransactionClient
+  ): Promise<BodyPartGauge | null> {
     const client = tx || prisma
     const gauge = await client.bodyPartGauge.findFirst({
       where: { userId },
       orderBy: { earnedAt: "desc" },
     })
-    return gauge as BodyPartGauge || null
+    return (gauge as BodyPartGauge) || null
   }
 
-  async save(bodyPartGauge: BodyPartGauge, tx?: TransactionClient): Promise<BodyPartGauge> {
+  async save(
+    bodyPartGauge: BodyPartGauge,
+    tx?: TransactionClient
+  ): Promise<BodyPartGauge> {
     const client = tx || prisma
     const savedGauge = await client.bodyPartGauge.create({
       data: {


### PR DESCRIPTION
## 🔍 개요 (Overview)
userId와 date로 특정 날짜의 캐릭터를 조회할 때 같은 날짜에 데이터가 여러 개일 경우 오류 발생

Closes #171 


## ✅ 작업 사항 (Work Done)
- [x] `findUnique` → `findFirst`로 변경하여 가장 최신 기록을 조회하도록 수정


## 📸 스크린샷 (Screenshots)
없음


##  reviewers에게
 - 같은 날짜의 데이터가 여러 개일 경우 `findUnique`에서 오류가 발생하는 문제였습니다. 그래서 `findFirst`로 변경하여 가장 최신 기록을 조회하도록 수정했습니다.
