### PR TITLE
[QA] 근로그 페이지 로그 목록 크기 조절

### DIFF
--- a/app/user/logs/components/LogItem.tsx
+++ b/app/user/logs/components/LogItem.tsx
@@ -29,7 +29,7 @@ const LogItem = ({ log, calTypeMaps }: LogItemProps) => {
             </C2>
             <C1 className="justify-self-center">{logDate.getDate()}</C1>
           </div>
-          <div className="flex col-span-2 justify-between gap-4">
+          <div className="flex col-span-2 justify-between">
             <div className="justify-center flex items-center">
               <Icon
                 name={

--- a/app/user/logs/components/LogList.tsx
+++ b/app/user/logs/components/LogList.tsx
@@ -6,30 +6,55 @@ import { LogListProps } from "@/app/user/logs/types"
 import React from "react"
 import LogItem from "@/app/user/logs/components/LogItem"
 import Loading from "@/app/loading"
+import Icon from "@/ds/components/atoms/icon/Icon"
 
 const LogList = ({
   isFetching,
   logsToDisplay,
   selectedDate,
   calTypeMaps,
+  isSlideUp,
+  setIsSlideUp,
 }: LogListProps) => {
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsSlideUp(!isSlideUp)
+  }
+
+  const handleClick = (e: React.MouseEvent) => {
+    setIsSlideUp(!isSlideUp)
+  }
   return (
-    <div className="relative flex flex-col gap-[9px] overflow-hidden h-full">
-      <div className="sticky top-0 px-2">
-        <S1>
-          {selectedDate ? `${dateToYmdSlash(selectedDate)}의 운동기록` : "이달의 운동 기록"}
+    <div className="relative flex h-full flex-col gap-[9px] overflow-hidden px-2 pt-4">
+      <div
+        className="sticky top-0 cursor-pointer px-2"
+        onTouchStart={handleTouchStart}
+        onClick={handleClick}
+      >
+        <S1 className="flex items-center gap-2">
+          {selectedDate
+            ? `${dateToYmdSlash(selectedDate)}의 운동기록`
+            : "이달의 운동 기록"}
+          <div
+            className={`flex h-6 w-6 transform items-center justify-center transition-transform duration-0 ${isSlideUp ? "" : "rotate-180"}`}
+          >
+            <Icon
+              name="downArrow"
+              color="primary"
+              fillColor="primary"
+              size={15}
+              viewBox="0 0 14 8"
+            />
+          </div>
         </S1>
       </div>
-      <div className="flex-1 overflow-auto scrollbar-none">
-        {isFetching 
-        ? <Loading /> 
-        : logsToDisplay.map((log) => (
-          <LogItem
-            key={log.id}
-            log={log}
-            calTypeMaps={calTypeMaps}
-          />
-        ))}
+      <div className="scrollbar-none flex-1 overflow-auto">
+        {isFetching ? (
+          <Loading />
+        ) : (
+          logsToDisplay.map((log) => (
+            <LogItem key={log.id} log={log} calTypeMaps={calTypeMaps} />
+          ))
+        )}
       </div>
     </div>
   )

--- a/app/user/logs/page.tsx
+++ b/app/user/logs/page.tsx
@@ -14,6 +14,7 @@ const UserLogsPage = () => {
   const [logsOnMonth, setLogsOnMonth] = useState<Log[]>([])
   const [logsToDisplay, setLogsToDisplay] = useState<Log[]>([])
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [isSlideUp, setIsSlideUp] = useState<boolean>(false)
 
   const [calMonth, setCalMonth] = useState<string>(() => {
     const now = new Date()
@@ -67,7 +68,7 @@ const UserLogsPage = () => {
   }
 
   return (
-    <div className="flex h-[calc(100dvh-100px)] w-full flex-col pb-[30px]">
+    <div className="relative flex h-[calc(100dvh-100px)] w-full flex-col pb-[30px]">
       <div className="flex-shrink-0">
         <CalendarHeader
           calendarRef={calendarRef}
@@ -82,12 +83,22 @@ const UserLogsPage = () => {
           onIconClick={handleIconClick}
         />
       </div>
-      <div className="min-h-0 flex-1">
+      <div
+        className={`min-h-0 flex-1 touch-pan-y transition-all duration-300 ease-out z-10 
+            rounded-t-lg border-t-1 border-x-1 border-[var(--color-secondary)]
+          ${ isSlideUp
+            ? "bg-white-100 animate-log-list-slide-up absolute inset-x-0 top-[50px] bottom-0 "
+            : "animate-log-list-slide-down"
+        }`}
+        
+      >
         <LogList
           isFetching={isFetching}
           logsToDisplay={logsToDisplay}
           selectedDate={selectedDate}
           calTypeMaps={calTypeMaps}
+          isSlideUp={isSlideUp}
+          setIsSlideUp={setIsSlideUp}
         />
       </div>
     </div>

--- a/app/user/logs/types.ts
+++ b/app/user/logs/types.ts
@@ -49,6 +49,8 @@ export interface LogListProps {
   logsToDisplay: Log[]
   selectedDate: string | null
   calTypeMaps: CalTypeMaps
+  isSlideUp: boolean
+  setIsSlideUp: Dispatch<SetStateAction<boolean>>
 }
 
 export interface LogItemProps {

--- a/ds/styles/globals.css
+++ b/ds/styles/globals.css
@@ -14,6 +14,24 @@
   }
 }
 
+@keyframes log-list-slide-up {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes log-list-slide-down {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
 @theme {
   --font-galmuri: var(--font-galmuri);
   --breakpoint-mb: 425px;
@@ -35,6 +53,7 @@
 
   /* animation */
   --animate-slide-up: slide-up 0.2s ease-out forwards;
+  --animate-log-list-slide-up: log-list-slide-up 0.3s ease-out forwards;
 }
 
 body {


### PR DESCRIPTION
## 🔍 개요 (Overview)
근로그 페이지 달력 밑 로그 목록 스크롤 구역 크기 조절 필요
=>  근로그 페이지 로그 목록 slide-up 기능 추가

This closes #206 

## ✅ 작업 사항 (Work Done)

- [x] 근로그 페이지 로그 목록 slide-up 기능 추가
- [x] 


## 📸 스크린샷 (Screenshots)

https://github.com/user-attachments/assets/e9dfa9e3-a455-4c5f-8e53-fedcf9339034




##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
