### PR TITLE
[QA] 임시 수정-캐릭터 get api 에 date param있는 경우

### DIFF
--- a/backend/infrastructure/repositories/PrBodyPartGaugeRepository.ts
+++ b/backend/infrastructure/repositories/PrBodyPartGaugeRepository.ts
@@ -29,7 +29,16 @@ export class PrBodyPartGaugeRepository implements BodyPartGaugeRepository {
     const whereCondition: any = { userId: id }
 
     if (date) {
-      whereCondition.earnedAt = date
+      const startDate = new Date(date)
+      startDate.setUTCHours(0, 0, 0, 0)
+
+      const endDate = new Date(startDate)
+      endDate.setUTCDate(startDate.getUTCDate() + 1)
+
+      whereCondition.earnedAt = {
+        gte: startDate,
+        lt: endDate,
+      }
     }
 
     const client = tx || prisma
@@ -39,8 +48,6 @@ export class PrBodyPartGaugeRepository implements BodyPartGaugeRepository {
         earnedAt: "desc",
       },
     })
-
-    console.log("userBodyPartGauge", userBodyPartGauge)
 
     return (userBodyPartGauge as BodyPartGauge) || null
   }


### PR DESCRIPTION

## 🔍 개요 (Overview)
date(yymmdd) -> Date -> 데이터 베이스에서 가져올때 earnedAt이 date의 범위에 포함되는 경우 중 가장 최신상태를 select
실제 earnedAt 날짜와 createdAt의 시간을 비교해서 가져와야 정확한 데이터임

## ✅ 작업 사항 (Work Done)

- [x] db에서 조회 시 where조건을 수정


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|<img width="424" height="748" alt="스크린샷 2025-08-26 오후 5 25 17" src="https://github.com/user-attachments/assets/f2ffcf95-4ba5-4b20-a8e1-28424799c113" />|<img width="422" height="750" alt="스크린샷 2025-08-26 오후 5 25 35" src="https://github.com/user-attachments/assets/d6f2602c-abc5-4e56-a382-ffec12bd20b2" />|

##  reviewers에게

- yymmddToDate()에서 시간을 설정안하는데, 데이터 찍어보니까 15:00로 되어있어서 일치하지 않아서 데이터를 못받아오는 이슈였습니다.
- createdAt의 시간과 earedAt날짜를 비교해서 받아와야 해당 기록의 정확한 캐릭터 상태입니다.(log 생성 시 수정 후 작업하도록 하겠습니다)
