### PR TITLE
[QA]운동기록 페이지 3차 qa 오류 수정

### DIFF
--- a/app/exercises/components/ExerciseList.tsx
+++ b/app/exercises/components/ExerciseList.tsx
@@ -39,6 +39,16 @@ const ExerciseList = () => {
     setData(exercise)
   }
 
+  console.log(data?.pages[0].data.length)
+  if (data?.pages[0].data.length === 0) {
+    return (
+      <C2 className="text-center">
+        아직 등록되지 않은 운동이에요 😅 <br />
+        다른 키워드로 검색해보세요!
+      </C2>
+    )
+  }
+
   return (
     <section className="relative">
       {isLoading && (

--- a/app/logs/components/AddWorkoutForm.tsx
+++ b/app/logs/components/AddWorkoutForm.tsx
@@ -12,7 +12,7 @@ const AddWorkoutForm = ({
   workoutData,
   setWorkoutData,
 }: AddWorkoutFormProps) => {
-  const { exerciseData, setMode, setOpen } = useLogsStore()
+  const { exerciseData, setMode, setOpen, setInit } = useLogsStore()
 
   const handleAddSet = (index: number) => {
     const newFormData = [...formData]
@@ -167,6 +167,7 @@ const AddWorkoutForm = ({
             },
           },
         ])
+        setInit()
       }
     },
     [exerciseData]

--- a/app/logs/components/AddWorkoutForm.tsx
+++ b/app/logs/components/AddWorkoutForm.tsx
@@ -3,7 +3,7 @@ import Workout from "@/ds/components/molecules/workout/Workout"
 import { useLogsStore } from "@/hooks/useLogsStore"
 import { Exercise } from "@/services/exercises/getExercises"
 import { useEffect } from "react"
-import { WorkoutItem, workoutTypes } from "../types"
+import { FormData, workoutTypes } from "../types"
 import { AddWorkoutFormProps } from "./type"
 
 const AddWorkoutForm = ({
@@ -123,7 +123,7 @@ const AddWorkoutForm = ({
   const handleTypeChange = (index: number, newType: string) => {
     setFormData((prev) => {
       const newData = [...prev]
-      newData[index].type = newType as WorkoutItem["type"]
+      newData[index].type = newType as FormData["type"]
       newData[index].data = [{ setCount: 1 }]
       return newData
     })
@@ -144,7 +144,7 @@ const AddWorkoutForm = ({
             title: (exerciseData as Exercise).name,
             type: workoutTypes[
               (exerciseData as Exercise).exerciseType
-            ] as WorkoutItem["type"],
+            ] as FormData["type"],
             data: [{ setCount: 1 }],
           },
         ])

--- a/app/logs/components/DateTimeInput.tsx
+++ b/app/logs/components/DateTimeInput.tsx
@@ -16,10 +16,14 @@ const DateTimeInput = ({
     const value = e.target.value
     const numberRegex = /^[0-9]{1,3}$/
 
-    if (numberRegex.test(value) || value === "") {
-      const numValue = parseInt(value) || 0
-      if (numValue >= 0 && numValue <= 999) {
-        setTotalDuration(numValue)
+    if (value === "") {
+      setTotalDuration(0)
+    } else {
+      if (numberRegex.test(value)) {
+        const numValue = parseInt(value)
+        if (numValue >= 0 && numValue <= 999) {
+          setTotalDuration(numValue)
+        }
       }
     }
   }
@@ -42,7 +46,7 @@ const DateTimeInput = ({
       <div className="flex items-center gap-2">
         <Icon name="clock" size={24} />
         <Input
-          value={totalDuration ?? 0}
+          value={totalDuration === 0 ? "" : totalDuration}
           onChange={handleChange}
           size="sm"
           type="number"

--- a/app/logs/components/type.ts
+++ b/app/logs/components/type.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from "react"
-import { CalIconType, WorkoutData, WorkoutItem } from "../types"
+import { CalIconType, WorkoutData, FormData } from "../types"
 
 export interface DateTypeProps {
   date: string
@@ -13,9 +13,9 @@ export interface WorkoutTypeSelectorProps {
 }
 
 export interface AddWorkoutFormProps {
-  formData: WorkoutItem[]
+  formData: FormData[]
   workoutData: WorkoutData[]
-  setFormData: Dispatch<SetStateAction<WorkoutItem[]>>
+  setFormData: Dispatch<SetStateAction<FormData[]>>
   setWorkoutData: Dispatch<SetStateAction<WorkoutData[]>>
 }
 
@@ -23,7 +23,7 @@ export interface WorkoutLogSaveButtonProps {
   calIconType: CalIconType | null
   date: string
   totalDuration: number
-  formData: WorkoutItem[]
+  formData: FormData[]
   workoutData: WorkoutData[]
 }
 

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react"
 import AddWorkoutForm from "./components/AddWorkoutForm"
 import DateTimeInput from "./components/DateTimeInput"
 import ExerciseListModal from "./components/ExerciseListModal"
-import { WorkoutData, WorkoutItem } from "./types"
+import { WorkoutData, FormData } from "./types"
 import WorkoutLogSaveButton from "./components/WorkoutLogSaveButton"
 import WorkoutTypeSelector from "./components/WorkoutTypeSelector"
 import { CalIconType } from "@/services/user/logs/createUserLogs"
@@ -17,9 +17,8 @@ const LogsPage = () => {
   const [calIconType, setCalIconType] = useState<CalIconType | null>(null)
   const [date, setDate] = useState(dayjs().format("YYYY.MM.DD"))
   const [totalDuration, setTotalDuration] = useState<number>(0)
-  const [formData, setFormData] = useState<WorkoutItem[]>([])
+  const [formData, setFormData] = useState<FormData[]>([])
   const [workoutData, setWorkoutData] = useState<WorkoutData[]>([])
-
   useEffect(() => {
     return () => {
       setInit()

--- a/app/logs/types.ts
+++ b/app/logs/types.ts
@@ -13,7 +13,7 @@ export const workoutTypes: Record<string, string> = {
 }
 
 //workout 컴포넌트에 사용되는 타입
-type WorkoutSetData = {
+type FormSetData = {
   setCount: number
   durationSeconds?: number | string
   distance?: string
@@ -21,11 +21,11 @@ type WorkoutSetData = {
   repetitionCount?: number
 }
 
-export type WorkoutItem = {
+export type FormData = {
   id: number
   title: string
   type: "duration" | "distance-duration" | "weight-reps" | "reps"
-  data: WorkoutSetData[]
+  data: FormSetData[]
 }
 
 //api 요청 시 사용되는 타입

--- a/app/logs/types.ts
+++ b/app/logs/types.ts
@@ -6,7 +6,7 @@ export enum CalIconType {
 
 //workout 컴포넌트에서 타입 선택 시 사용되는 타입
 export const workoutTypes: Record<string, string> = {
-  STRENGTH: "reps",
+  STRENGTH: "weight-reps",
   PLYOMETRICS: "duration",
   CARDIO: "distance-duration",
   WEIGHTLIFTING: "weight-reps",


### PR DESCRIPTION
## 🔍 개요 (Overview)
운동기록 페이지 3차 qa 오류 수정
(예: Closes #211 )


## ✅ 작업 사항 (Work Done)
- [x]  검색결과 없는 경우에 대한 처리
- [x]  운동 토탈 시간 0이 사라지지 않음
- [x]  벤치프레스 추가 시 워크아웃이 횟수만 나옴
- [x]  이전에 삭제했거나 추가했던 운동 추가안되는 이슈
- [ ]  워크아웃 삭제에 대한 UI 수정 (상단에 변경아이콘 + X 아이콘)
- [ ]  스크롤 시 최상단으로 이동하는 이슈

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|        |       |


##  reviewers에게

사용자가 운동 기록을 순차적으로 넣지않을때 seq값이 제대로 반영이 안되고 있는 이슈를 발견했습니다...
ui에 보여지는 데이터 state(formData)에는 의도대로 저장되고 있는데, 
db 보내는 데이터 state(workoutData)에서는 seq가 엉키고있어요..,.,.,.

무!조!건! 해결하고 자겠습니다!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
걱정마셔요 불안해하지마셔요 믿으셔야합니다!!!!!!!!!!
