### PR TITLE
운동 기록 삭제 시, 관련 뱃지 삭제 로직 수정

### DIFF
--- a/backend/application/user/logs/services/BadgeDeletionService.ts
+++ b/backend/application/user/logs/services/BadgeDeletionService.ts
@@ -143,7 +143,7 @@ export class BadgeDeletionService {
       (log) => log.id !== logToDelete.id
     )
     const workoutDatesThisWeek = new Set(
-      remainingWeekLogs.map((log) => log.logDate.toDateString())
+      remainingWeekLogs.map((log) => log.logDate.toLocaleDateString())
     )
 
     if (workoutDatesThisWeek.size < 3) {
@@ -207,14 +207,15 @@ export class BadgeDeletionService {
     tx?: TransactionClient
   ): Promise<void> {
     const deletedLogDate = new Date(logToDelete.logDate)
+    const deletedLogCreatedAt = new Date(logToDelete.createdAt)
 
     // 해당 로그와 같은 날짜 및 시간에 생성된 신기록 뱃지들 조회
     const recordBadgesOnDate =
-      await this.userBadgeRepository.findByUserIdAndOptions(
+      await this.userBadgeRepository.findByUserIdAndDates(
         userId,
         [...RECORD_BADGE_IDS],
         deletedLogDate,
-        deletedLogDate,
+        deletedLogCreatedAt,
         undefined,
         undefined,
         tx
@@ -229,41 +230,46 @@ export class BadgeDeletionService {
 
       if (userBadge.badgeId === BADGE_IDS.BENCH_PRESS_RECORD) {
         deletePromises.push(
-          this.benchPressRecordRepository.deleteByUserIdAndEarnedAt(
+          this.benchPressRecordRepository.deleteByUserIdAndDates(
             userId,
             userBadge.earnedAt,
+            userBadge.createdAt,
             tx
           )
         )
       } else if (userBadge.badgeId === BADGE_IDS.SQUAT_RECORD) {
         deletePromises.push(
-          this.squatRecordRepository.deleteByUserIdAndEarnedAt(
+          this.squatRecordRepository.deleteByUserIdAndDates(
             userId,
             userBadge.earnedAt,
+            userBadge.createdAt,
             tx
           )
         )
       } else if (userBadge.badgeId === BADGE_IDS.DEADLIFT_RECORD) {
         deletePromises.push(
-          this.deadliftRecordRepository.deleteByUserIdAndEarnedAt(
+          this.deadliftRecordRepository.deleteByUserIdAndDates(
             userId,
             userBadge.earnedAt,
+            userBadge.createdAt,
             tx
           )
         )
       } else if (userBadge.badgeId === BADGE_IDS.RUNNING_RECORD) {
         deletePromises.push(
-          this.runningRecordRepository.deleteByUserIdAndEarnedAt(
+          this.runningRecordRepository.deleteByUserIdAndDates(
             userId,
             userBadge.earnedAt,
+            userBadge.createdAt,
             tx
           )
         )
       } else if (userBadge.badgeId === BADGE_IDS.BIG_THREE_RECORD) {
         deletePromises.push(
-          this.bigThreeRecordRepository.deleteByUserIdAndEarnedAt(
+          this.bigThreeRecordRepository.deleteByUserIdAndDates(
             userId,
             userBadge.earnedAt,
+            userBadge.createdAt,
             tx
           )
         )

--- a/backend/domain/repositories/BenchPressRecordRepository.ts
+++ b/backend/domain/repositories/BenchPressRecordRepository.ts
@@ -12,5 +12,5 @@ export interface BenchPressRecordRepository {
     tx?: TransactionClient
   ): Promise<BenchPressRecord[]>
   save(record: BenchPressRecord, tx?: TransactionClient): Promise<BenchPressRecord>
-  deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean>
+  deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean>
 }

--- a/backend/domain/repositories/BigThreeRecordRepository.ts
+++ b/backend/domain/repositories/BigThreeRecordRepository.ts
@@ -12,5 +12,5 @@ export interface BigThreeRecordRepository {
     tx?: TransactionClient
   ): Promise<BigThreeRecord[]>
   save(record: BigThreeRecord, tx?: TransactionClient): Promise<BigThreeRecord>
-  deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean>
+  deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean>
 }

--- a/backend/domain/repositories/DeadliftRecordRepository.ts
+++ b/backend/domain/repositories/DeadliftRecordRepository.ts
@@ -12,5 +12,5 @@ export interface DeadliftRecordRepository {
     tx?: TransactionClient
   ): Promise<DeadliftRecord[]>
   save(record: DeadliftRecord, tx?: TransactionClient): Promise<DeadliftRecord>
-  deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean>
+  deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean>
 }

--- a/backend/domain/repositories/RunningRecordRepository.ts
+++ b/backend/domain/repositories/RunningRecordRepository.ts
@@ -12,5 +12,5 @@ export interface RunningRecordRepository {
     tx?: TransactionClient
   ): Promise<RunningRecord[]>
   save(record: RunningRecord, tx?: TransactionClient): Promise<RunningRecord>
-  deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean>
+  deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date,  tx?: TransactionClient): Promise<boolean>
 }

--- a/backend/domain/repositories/SquatRecordRepository.ts
+++ b/backend/domain/repositories/SquatRecordRepository.ts
@@ -12,5 +12,5 @@ export interface SquatRecordRepository {
     tx?: TransactionClient
   ): Promise<SquatRecord[]>
   save(record: SquatRecord, tx?: TransactionClient): Promise<SquatRecord>
-  deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean>
+  deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean>
 }

--- a/backend/domain/repositories/UserBadgeRepository.ts
+++ b/backend/domain/repositories/UserBadgeRepository.ts
@@ -10,7 +10,7 @@ export interface UserBadgeRepository {
     tx?: TransactionClient
   ): Promise<UserBadge[] | null>
   findByUserIdAndOptions(
-    userId: string, 
+    userId: string,
     badgeIds?: number[],
     startDate?: Date,
     endDate?: Date,
@@ -18,9 +18,25 @@ export interface UserBadgeRepository {
     limit?: number,
     tx?: TransactionClient
   ): Promise<UserBadge[]>
+  findByUserIdAndDates(
+    userId: string,
+    badgeIds: number[],
+    deletedLogDate: Date,
+    deletedLogCreatedAt: Date,
+    sortOrder?: "asc" | "desc",
+    limit?: number,
+    tx?: TransactionClient
+  ): Promise<UserBadge[]>
   save(userBadge: UserBadge, tx?: TransactionClient): Promise<UserBadge>
-  saveMany(userBadges: UserBadge[], tx?: TransactionClient): Promise<UserBadge[]>
-  update(id: number, userBadge: Partial<UserBadge>, tx?: TransactionClient): Promise<UserBadge | null>
+  saveMany(
+    userBadges: UserBadge[],
+    tx?: TransactionClient
+  ): Promise<UserBadge[]>
+  update(
+    id: number,
+    userBadge: Partial<UserBadge>,
+    tx?: TransactionClient
+  ): Promise<UserBadge | null>
   delete(id: number, tx?: TransactionClient): Promise<boolean>
   deleteMany(userBadgeIds: number[], tx?: TransactionClient): Promise<boolean>
 }

--- a/backend/infrastructure/repositories/PrBenchPressRecordRepository.ts
+++ b/backend/infrastructure/repositories/PrBenchPressRecordRepository.ts
@@ -45,19 +45,21 @@ export class PrBenchPressRecordRepository implements BenchPressRecordRepository 
       data: {
         userId: record.userId,
         weight: record.weight,
-        earnedAt: record.earnedAt
+        earnedAt: record.earnedAt,
+        createdAt: record.createdAt
       }
     })
     return savedRecord as BenchPressRecord
   }
 
-  async deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean> {
+  async deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean> {
     try {
       const client = tx || prisma
       await client.benchPressRecord.deleteMany({
         where: {
           userId,
-          earnedAt
+          earnedAt,
+          createdAt
         }
       })
       return true

--- a/backend/infrastructure/repositories/PrBigThreeRecordRepository.ts
+++ b/backend/infrastructure/repositories/PrBigThreeRecordRepository.ts
@@ -45,19 +45,21 @@ export class PrBigThreeRecordRepository implements BigThreeRecordRepository {
       data: {
         userId: record.userId,
         weight: record.weight,
-        earnedAt: record.earnedAt
+        earnedAt: record.earnedAt,
+        createdAt: record.createdAt
       }
     })
     return savedRecord as BigThreeRecord
   }
 
-  async deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean> {
+  async deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean> {
     try {
       const client = tx || prisma
       await client.bigThreeRecord.deleteMany({
         where: {
           userId,
-          earnedAt
+          earnedAt,
+          createdAt
         }
       })
       return true

--- a/backend/infrastructure/repositories/PrDeadliftRecordRepository.ts
+++ b/backend/infrastructure/repositories/PrDeadliftRecordRepository.ts
@@ -45,19 +45,21 @@ export class PrDeadliftRecordRepository implements DeadliftRecordRepository {
       data: {
         userId: record.userId,
         weight: record.weight,
-        earnedAt: record.earnedAt
+        earnedAt: record.earnedAt,
+        createdAt: record.createdAt
       }
     })
     return savedRecord as DeadliftRecord
   }
 
-  async deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean> {
+  async deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean> {
     try {
       const client = tx || prisma
       await client.deadliftRecord.deleteMany({
         where: {
           userId,
-          earnedAt
+          earnedAt,
+          createdAt
         }
       })
       return true

--- a/backend/infrastructure/repositories/PrRunningRecordRepository.ts
+++ b/backend/infrastructure/repositories/PrRunningRecordRepository.ts
@@ -45,19 +45,21 @@ export class PrRunningRecordRepository implements RunningRecordRepository {
       data: {
         userId: record.userId,
         distance: record.distance,
-        earnedAt: record.earnedAt
+        earnedAt: record.earnedAt,
+        createdAt: record.createdAt
       }
     })
     return savedRecord as RunningRecord
   }
 
-  async deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean> {
+  async deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean> {
     try {
       const client = tx || prisma
       await client.runningRecord.deleteMany({
         where: {
           userId,
-          earnedAt
+          earnedAt,
+          createdAt
         }
       })
       return true

--- a/backend/infrastructure/repositories/PrSquatRecordRepository.ts
+++ b/backend/infrastructure/repositories/PrSquatRecordRepository.ts
@@ -45,19 +45,21 @@ export class PrSquatRecordRepository implements SquatRecordRepository {
       data: {
         userId: record.userId,
         weight: record.weight,
-        earnedAt: record.earnedAt
+        earnedAt: record.earnedAt,
+        createdAt: record.createdAt
       }
     })
     return savedRecord as SquatRecord
   }
 
-  async deleteByUserIdAndEarnedAt(userId: string, earnedAt: Date, tx?: TransactionClient): Promise<boolean> {
+  async deleteByUserIdAndDates(userId: string, earnedAt: Date, createdAt: Date, tx?: TransactionClient): Promise<boolean> {
     try {
       const client = tx || prisma
       await client.squatRecord.deleteMany({
         where: {
           userId,
-          earnedAt
+          earnedAt,
+          createdAt
         }
       })
       return true


### PR DESCRIPTION
## 🔍 개요 (Overview)
운동 기록 등록 시, 관련 뱃지 등록 로직 수정으로 인해, 삭제 시에도 관련 로직 수정

This closes #227 

## ✅ 작업 사항 (Work Done)

- [x] 해당 운동 기록의 logDate와 createdAt 모두 비교하도록 BadgeDeletionService 수정
- [x] 각 레코드별 Repository 인터페이스 및 구현체 수정
- [x] UserBadge 조회시에도 logDate와 createdAt 모두 비교하도록 repository 인터페이스 및 구현체 수정

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|        |       |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
