### PR TITLE
fix: #242 메인페이지 사용자 뱃지 가져오는 로직 수정

### DIFF
--- a/backend/application/user/badges/usecases/GetUserBadgeListUsecase.ts
+++ b/backend/application/user/badges/usecases/GetUserBadgeListUsecase.ts
@@ -28,7 +28,7 @@ export class GetUserBadgeListUsecase {
       ? await this.userBadgeRepository.findLatestByBadgeIds(query.userId)
       : await this.userBadgeRepository.findByUserId(
           query.userId,
-          query?.limit ? query.limit : undefined,
+          undefined,
           query?.period
         )
     if (!userBadges) {

--- a/backend/application/user/badges/usecases/GetUserBadgeListUsecase.ts
+++ b/backend/application/user/badges/usecases/GetUserBadgeListUsecase.ts
@@ -25,7 +25,7 @@ export class GetUserBadgeListUsecase {
     })
 
     let userBadges: UserBadge[] | null = query?.limit
-      ? await this.userBadgeRepository.findLatestByBadgeIds(query.userId)
+      ? await this.userBadgeRepository.findLatestByBadgeIds(query.userId, query.limit)
       : await this.userBadgeRepository.findByUserId(
           query.userId,
           undefined,

--- a/backend/application/user/badges/usecases/GetUserBadgeListUsecase.ts
+++ b/backend/application/user/badges/usecases/GetUserBadgeListUsecase.ts
@@ -24,12 +24,13 @@ export class GetUserBadgeListUsecase {
       )
     })
 
-    let userBadges: UserBadge[] | null =
-      await this.userBadgeRepository.findByUserId(
-        query.userId,
-        query?.limit ? query.limit : 10,
-        query?.period
-      )
+    let userBadges: UserBadge[] | null = query?.limit
+      ? await this.userBadgeRepository.findLatestByBadgeIds(query.userId)
+      : await this.userBadgeRepository.findByUserId(
+          query.userId,
+          query?.limit ? query.limit : undefined,
+          query?.period
+        )
     if (!userBadges) {
       return new GetUserBadgeListDto(getBadgesDtos, null)
     }

--- a/backend/domain/repositories/UserBadgeRepository.ts
+++ b/backend/domain/repositories/UserBadgeRepository.ts
@@ -5,6 +5,7 @@ export interface UserBadgeRepository {
   findAll(tx?: TransactionClient): Promise<UserBadge[]>
   findLatestByBadgeIds(
     userId: string,
+    limit: number,
     tx?: TransactionClient
   ): Promise<UserBadge[]>
   findByUserId(

--- a/backend/domain/repositories/UserBadgeRepository.ts
+++ b/backend/domain/repositories/UserBadgeRepository.ts
@@ -3,6 +3,10 @@ import { TransactionClient } from "@/backend/domain/common/TransactionClient"
 
 export interface UserBadgeRepository {
   findAll(tx?: TransactionClient): Promise<UserBadge[]>
+  findLatestByBadgeIds(
+    userId: string,
+    tx?: TransactionClient
+  ): Promise<UserBadge[]>
   findByUserId(
     userId: string,
     limit?: number,

--- a/backend/infrastructure/repositories/PrUserBadgeRepository.ts
+++ b/backend/infrastructure/repositories/PrUserBadgeRepository.ts
@@ -10,6 +10,25 @@ export class PrUserBadgeRepository implements UserBadgeRepository {
     return userBadges.map(this.toDomain)
   }
 
+  async findLatestByBadgeIds(
+    userId: string,
+    tx?: TransactionClient
+  ): Promise<UserBadge[]> {
+    const whereCondition: any = { userId }
+
+    const client = tx || prisma
+    const userBadges = await client.userBadge.findMany({
+      where: whereCondition,
+      distinct: ["badgeId"],
+      orderBy: {
+        earnedAt: "desc",
+      },
+      take: 6,
+    })
+
+    return userBadges as UserBadge[]
+  }
+
   async findByUserId(
     userId: string,
     limit?: number,

--- a/backend/infrastructure/repositories/PrUserBadgeRepository.ts
+++ b/backend/infrastructure/repositories/PrUserBadgeRepository.ts
@@ -12,6 +12,7 @@ export class PrUserBadgeRepository implements UserBadgeRepository {
 
   async findLatestByBadgeIds(
     userId: string,
+    limit: number,
     tx?: TransactionClient
   ): Promise<UserBadge[]> {
     const whereCondition: any = { userId }
@@ -23,7 +24,7 @@ export class PrUserBadgeRepository implements UserBadgeRepository {
       orderBy: {
         earnedAt: "desc",
       },
-      take: 6,
+      take: limit,
     })
 
     return userBadges as UserBadge[]


### PR DESCRIPTION
## 🔍 개요 (Overview)
메인페이지 사용자 뱃지 가져오는 로직 수정
This closes #242 


## ✅ 작업 사항 (Work Done)

- [x] 메인페이지에서 가져올 때는 badgeId를 distinct로 가져오도록 수정
- [x] Usecase 에서 limit 여부에 따라 분기


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|        |       |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
