### PR TITLE
[QA] 메인페이지 운동추가 아이콘 깨짐 이슈

### DIFF
--- a/static/svgs/svgList.tsx
+++ b/static/svgs/svgList.tsx
@@ -186,46 +186,41 @@ export const svgList = {
         />
       </g>
       <defs>
-        <defs>
-          <filter
-            id="filter0_d_466_5253"
-            x="0.833984"
-            y="4.7915"
-            width="23.334"
-            height="21.4165"
-            filterUnits="userSpaceOnUse"
-            colorInterpolationFilters="sRGB"
-          >
-            <feFlood floodOpacity="0" result="BackgroundImageFix" />
-            <feColorMatrix
-              in="SourceAlpha"
-              type="matrix"
-              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-              result="hardAlpha"
-            />
-            <feOffset dy="3" />
-            <feGaussianBlur stdDeviation="2" />
-            <feComposite in2="hardAlpha" operator="out" />
-            <feColorMatrix
-              type="matrix"
-              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
-            />
-            <feBlend
-              mode="normal"
-              in2="BackgroundImageFix"
-              result="effect1_dropShadow_466_5253"
-            />
-            <feBlend
-              mode="normal"
-              in="SourceGraphic"
-              in2="effect1_dropShadow_466_5253"
-              result="shape"
-            />
-          </filter>
-          <clipPath id="clip0_466_5253">
-            <rect width="3" height="3" transform="translate(11 10)" />
-          </clipPath>
-        </defs>
+        <filter
+          id="filter0_d_466_5253"
+          x="0.833984"
+          y="4.7915"
+          width="23.334"
+          height="21.4165"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dy="3" />
+          <feGaussianBlur stdDeviation="2" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow_466_5253"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_466_5253"
+            result="shape"
+          />
+        </filter>
         <clipPath id="clip0_466_5253">
           <rect width="3" height="3" transform="translate(11 10)" />
         </clipPath>


### PR DESCRIPTION
## 🔍 개요 (Overview)

메인페이지 운동 추가 버튼 아이콘이 특정 환경(safari || android)에서 깨지는 이슈 해결
(예: Closes #271 )


## ✅ 작업 사항 (Work Done)

- [x] svg 수정
  - 중복 path 제거
  - mask가 필요하지 않아서 제거
  - filter를 테두리가 아닌 배경에 적용
  - 각 요소 순서 수정(배경->테두리->+ 순으로 z index가지도록) (filter는 그림자에 대한 부분, 이 알파값때문에 이슈가 있었던 것으로 보임)

## 📸 스크린샷 (Screenshots)

(아래 이미지는 safari 브라우저에서 확인한 화면입니다.)
| Before | After |
| :----: | :---: |
|<img width="149" height="112" alt="스크린샷 2025-11-10 오후 4 24 11" src="https://github.com/user-attachments/assets/6dccf85c-0fb4-4021-abf1-34871bad8ce9" />|<img width="393" height="335" alt="스크린샷 2025-11-10 오후 4 24 33" src="https://github.com/user-attachments/assets/ed5c28a0-3ab7-455d-a657-f62b2fb16bc4" />|

##  reviewers에게

- 해당 이슈에 대해서 파악하면서 [작성한 글](https://zu0p.tistory.com/45)이 있어서 공유합니다! 궁금한 점이나 보충할 부분이 있다면 알려주세요~ 