### PR TITLE
[Fix] #325 운동 로그 생성 오류

### DIFF
--- a/app/api/user/logs/route.ts
+++ b/app/api/user/logs/route.ts
@@ -112,6 +112,7 @@ export async function POST(request: NextRequest) {
         { status: 200 }
       )
     } else {
+      console.log(`log creation failed : ${result.message}`);
       return NextResponse.json({ message: "error" }, { status: 400 })
     }
   } catch (error) {

--- a/backend/infrastructure/repositories/PrTransactionManager.ts
+++ b/backend/infrastructure/repositories/PrTransactionManager.ts
@@ -6,6 +6,9 @@ export class PrTransactionManager implements TransactionManager {
   async executeInTransaction<T>(callback: (tx: TransactionClient) => Promise<T>): Promise<T> {
     return await prisma.$transaction(async (tx) => {
       return await callback(tx)
+    }, {
+      maxWait: 10000, // 10초
+      timeout: 30000, // 30초
     })
   }
 }

--- a/hooks/useCreateUserLogs.ts
+++ b/hooks/useCreateUserLogs.ts
@@ -29,8 +29,7 @@ export const useCreateUserLogs = () => {
         })
       }
     },
-    onError: (error) => {
-      console.log(error)
+    onError: () => {
       showToast({
         message: "운동 기록 저장에 실패했습니다 😢 다시 시도해주세요",
         variant: "error",

--- a/hooks/useUpdateUserInfo.ts
+++ b/hooks/useUpdateUserInfo.ts
@@ -7,22 +7,21 @@ export const useUpdateUserInfo = () => {
 
   return useMutation({
     mutationFn: (data: Request) => updateUserInfo(data),
-    onSuccess: (res) => {
-      if (res.message === "success") {
-        showToast({
-          message: "저장이 완료되었습니다!",
-          variant: "info",
-          position: "bottom",
-          duration: 3000,
-        })
-      } else if (res.message === "error") {
-        showToast({
-          message: "다시 시도해주세요😥",
-          variant: "error",
-          position: "bottom",
-          duration: 3000,
-        })
-      }
+    onSuccess: () => {
+      showToast({
+        message: "저장이 완료되었습니다!",
+        variant: "info",
+        position: "bottom",
+        duration: 3000,
+      })
+    },
+    onError: () => {
+      showToast({
+        message: "다시 시도해주세요😥",
+        variant: "error",
+        position: "bottom",
+        duration: 3000,
+      })
     },
   })
 }

--- a/utils/api/apiClient.ts
+++ b/utils/api/apiClient.ts
@@ -15,7 +15,16 @@ class ApiClient {
       ...options,
     })
 
-    return response.json()
+    const data = await response.json()
+
+    if (!response.ok) {
+      throw new Error(
+        data.message ||
+        `HTTP ${response.status}: ${response.statusText}`
+      )
+    }
+
+    return data
   }
 
   async get<T>(endpoint: string): Promise<T> {


### PR DESCRIPTION
## 🔍 개요 (Overview)
1. Prisma 트랜잭션 타임아웃 기본 5초에서 30초로 수정
2. API 응답 4xx, 5xx 이 `onError` 에서 처리되도록 ApiClient에서 Error throw
(Closes #325)

## ✅ 작업 사항 (Work Done)

- [x] PrismaTransactionManager에 timeout 속성 추가
- [x] ApiClient에 응답 status 체크 추가


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
