### PR TITLE
[fix] 이메일 중복 체크 api 응답 상태 코드 수정

### DIFF
--- a/backend/application/user/email/usecases/CheckEmailUsecase.ts
+++ b/backend/application/user/email/usecases/CheckEmailUsecase.ts
@@ -11,7 +11,7 @@ export class CheckEmailUsecase {
 
       if (!email) {
         return {
-          status: 400,
+          status: 200,
           message: "이메일을 입력해주세요",
           isAvailable: false,
         }
@@ -20,7 +20,7 @@ export class CheckEmailUsecase {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
       if (!emailRegex.test(email)) {
         return {
-          status: 400,
+          status: 200,
           message: "올바른 이메일 형식이 아닙니다",
           isAvailable: false,
         }
@@ -30,7 +30,7 @@ export class CheckEmailUsecase {
 
       if (existingUser) {
         return {
-          status: 409,
+          status: 200,
           message: "이미 사용 중인 이메일입니다",
           isAvailable: false,
         }


### PR DESCRIPTION
## 🔍 개요 (Overview)

이메일 중복 체크 API 검증 성공 시 40X를 반환해 apiClient에서 에러로 처리되는 문제 수정
(예: Closes #330 )


## ✅ 작업 사항 (Work Done)

- [x] 검증 성공 응답은 200으로 통일하여 에러 처리

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|   <img width="202" height="421" alt="image" src="https://github.com/user-attachments/assets/4c3dc387-aef0-4ace-a9eb-00f1b92e06b0" /> |   <img width="210" height="444" alt="image" src="https://github.com/user-attachments/assets/6bc75ccf-07f4-456d-862d-50388a0132b4" /> |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
