### PR TITLE
[Fix] #334 workout 컴포넌트 가운데 정렬 깨짐 수정

### DIFF
--- a/backend/application/user/logs/services/badge-achievement/RecordBadgeService.ts
+++ b/backend/application/user/logs/services/badge-achievement/RecordBadgeService.ts
@@ -68,6 +68,8 @@ export class RecordBadgeService {
       )
     )
 
+    if (recordWorkouts.length === 0) return awardedBadges
+
     // 이번 로그에서의 최대값
     const logMaxRecords = {
       benchPress: Math.max(
@@ -194,7 +196,10 @@ export class RecordBadgeService {
       )
       await this.runningRecordRepository.save(newRecord, tx)
 
-      if (logMaxRecords.running >= RECORD_MINIMUMS.RUNNING) {
+      if (
+        Math.floor(logMaxRecords.running) > Math.floor(existingRecords.running?.distance || 0)
+        && logMaxRecords.running >= RECORD_MINIMUMS.RUNNING
+      ) {
         const userBadge = new UserBadge(
           0,
           BADGE_IDS.RUNNING_RECORD,
@@ -206,6 +211,7 @@ export class RecordBadgeService {
       }
     }
 
+    // 3대 운동 (벤치 프레스, 데드리프트, 스쿼트)
     const currentBigThree =
       Math.max(
         logMaxRecords.benchPress,

--- a/ds/components/molecules/workout/Workout.tsx
+++ b/ds/components/molecules/workout/Workout.tsx
@@ -107,9 +107,12 @@ const Workout: React.FC<WorkoutProps> = ({
                   : ""
               }
               onChange={(e) => {
-                const minutes = Number(e.target.value) || 0
-                const seconds = (Number(value) || 0) % 60
-                onDataChange?.(index, field, minutes * 60 + seconds, seq)
+                const inputValue = e.target.value
+                if (/^[0-9]{0,3}$/.test(inputValue)) {
+                  const minutes = Number(inputValue) || 0
+                  const seconds = (Number(value) || 0) % 60
+                  onDataChange?.(index, field, minutes * 60 + seconds, seq)
+                }
               }}
             />
             <C2 className="text-center">:</C2>
@@ -120,9 +123,12 @@ const Workout: React.FC<WorkoutProps> = ({
               className="scale-[62.5%] text-center text-[16px]"
               value={Number(value) > 0 ? (Number(value) % 60).toString() : ""}
               onChange={(e) => {
-                const seconds = Number(e.target.value) || 0
-                const minutes = Math.floor((Number(value) || 0) / 60)
-                onDataChange?.(index, field, minutes * 60 + seconds, seq)
+                const inputValue = e.target.value
+                if (/^[0-5]?[0-9]?$/.test(inputValue)) {
+                  const seconds = Number(inputValue) || 0
+                  const minutes = Math.floor((Number(value) || 0) / 60)
+                  onDataChange?.(index, field, minutes * 60 + seconds, seq)
+                }
               }}
             />
           </div>

--- a/ds/components/molecules/workout/Workout.tsx
+++ b/ds/components/molecules/workout/Workout.tsx
@@ -131,7 +131,7 @@ const Workout: React.FC<WorkoutProps> = ({
         const minutes = Math.floor((Number(value) || 0) / 60)
         const seconds = (Number(value) || 0) % 60
         return (
-          <C2 key={`${field}-${index}`} className="self-center">
+          <C2 key={`${field}-${index}`} className="flex self-center justify-center">
             {minutes}:{seconds.toString().padStart(2, "0")}
           </C2>
         )

--- a/ds/components/molecules/workout/Workout.tsx
+++ b/ds/components/molecules/workout/Workout.tsx
@@ -97,7 +97,7 @@ const Workout: React.FC<WorkoutProps> = ({
             className="flex items-center justify-center"
           >
             <Input
-              size="sm"
+              size="md"
               placeholder="분"
               inputMode="numeric"
               className="scale-[62.5%] text-center text-[16px]"
@@ -114,7 +114,7 @@ const Workout: React.FC<WorkoutProps> = ({
             />
             <C2 className="text-center">:</C2>
             <Input
-              size="sm"
+              size="md"
               placeholder="초"
               inputMode="numeric"
               className="scale-[62.5%] text-center text-[16px]"
@@ -145,14 +145,17 @@ const Workout: React.FC<WorkoutProps> = ({
           key={`${field}-${index}`}
         >
           <Input
-            size="sm"
+            size="md"
             placeholder={fieldConfig.placeholders[fieldIndex] || ""}
             className="scale-[62.5%] text-center text-[16px]"
             inputMode="numeric"
             value={value || ""}
             onChange={(e) => {
               const inputValue = e.target.value
-              const numberRegex = /^[0-9]{0,3}$/
+              const isDecimalField = fieldConfig.fields[fieldIndex] === "weight" || fieldConfig.fields[fieldIndex] === "distance"
+              const numberRegex = isDecimalField 
+                ? /^[0-9]{0,3}(\.[0-9]{0,2})?$/
+                : /^[0-9]{0,3}$/
               if (numberRegex.test(inputValue)) {
                 onDataChange?.(index, field, inputValue, seq)
               }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,9 +146,9 @@ model Workout {
   seq              Int
   exerciseName     String @map("exercise_name")
   setCount         Int     @map("set_count")
-  weight           Int?
+  weight           Float?
   repetitionCount  Int?   @map("repetition_count")
-  distance         Int?
+  distance         Float?
   durationSeconds  Int?   @map("duration_seconds")
 
   // Relations


### PR DESCRIPTION
## 🔍 개요 (Overview)
Workout 컴포넌트 시간 필드 가운데 정렬 깨짐 수정
(예: Closes #334 )


## ✅ 작업 사항 (Work Done)
- [x] Workout 컴포넌트 시간 필드 가운데 정렬 추가
- [x] 무게, 거리 입력 필드 소수점 허용하게 수정
    - [x] 입력 필드 정규식 수정
    - [x] prisma schema에 타입 수정
    - [x] 달리기 신기록 비교에 Math.floor로 1km 단위로 비교하도록 추가


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|  <img width="339" height="193" alt="image" src="https://github.com/user-attachments/assets/e97a73e2-dcd4-49a5-bbb5-b70b568c272a" /> | <img width="337" height="158" alt="image" src="https://github.com/user-attachments/assets/7f7c6ef7-3dd0-480c-9921-90319753dfdd" /> |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
