### PR TITLE
[Refactor] Input 비밀번호 토글 추가 / Input 내부 유효성 검사 기능 적용

### DIFF
--- a/app/signup/[steps]/components/Step1Form.tsx
+++ b/app/signup/[steps]/components/Step1Form.tsx
@@ -7,19 +7,7 @@ import { ChangeEvent, useState, useTransition } from "react"
 
 import { useSignupStore } from "@/hooks/useSignupStore"
 import { SignupData } from "@/app/signup/[steps]/types"
-
-const emailErrorRules = [
-  {
-    when: (value: string) => value.trim() === "",
-    message: "이메일을 입력해주세요",
-  },
-  {
-    when: (value: string) =>
-      value.length > 0 &&
-      !/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
-    message: "올바른 이메일 형식이 아닙니다",
-  },
-]
+import { emailErrorRules } from "@/utils/validation"
 
 function Step1Form() {
   const router = useRouter()

--- a/app/signup/[steps]/components/Step2Form.tsx
+++ b/app/signup/[steps]/components/Step2Form.tsx
@@ -7,53 +7,52 @@ import { S1 } from "@/ds/components/atoms/text/TextWrapper"
 import { useSignupStore } from "@/hooks/useSignupStore"
 import { ValidatePassword } from "@/app/signup/[steps]/types"
 
+const passwordValidations = [
+  {
+    label: "영문포함",
+    validate: (value: string) => /[a-zA-Z]/.test(value),
+  },
+  {
+    label: "숫자포함",
+    validate: (value: string) => /[0-9]/.test(value),
+  },
+  {
+    label: "8자~20자",
+    validate: (value: string) => value.length >= 8 && value.length <= 20,
+  },
+]
+
 const Step2Form = () => {
   const router = useRouter()
   const { set2Data } = useSignupStore()
 
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<ValidatePassword>({
     password: "",
     passwordConfirm: "",
   })
-  const [validation, setValidation] = useState({
-    alphabet: false,
-    number: false,
-    length: false,
-    match: false,
-    passwordSuccess: false,
-  })
-
-  const validateCheck = ({ password, passwordConfirm }: ValidatePassword) => {
-    const alphabet = /[a-zA-Z]/.test(password)
-    const number = /[0-9]/.test(password)
-    const length = password.length >= 8 && password.length <= 20
-    const match = password === passwordConfirm && password !== ""
-    const passwordSuccess = alphabet && number && length && match
-
-    return { alphabet, number, length, match, passwordSuccess }
-  }
+  const [isPasswordValid, setIsPasswordValid] = useState<boolean>(false)
+  const [isPasswordMatch, setIsPasswordMatch] = useState<boolean>(false)
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    setFormData({ ...formData, [name]: value })
-
-    const result = validateCheck({
-      password: name === "password" ? value : formData.password,
-      passwordConfirm:
-        name === "passwordConfirm" ? value : formData.passwordConfirm,
-    })
-    setValidation(result)
+    const nextFormData = { ...formData, [name]: value }
+    setFormData(nextFormData)
+    setIsPasswordMatch(
+      nextFormData.passwordConfirm !== "" &&
+        nextFormData.password !== "" &&
+        nextFormData.passwordConfirm === nextFormData.password
+    )
   }
 
   const handleNext = () => {
-    if (!validation.passwordSuccess) return
+    if (!isPasswordValid || !isPasswordMatch) return
 
     set2Data({ password: formData.password })
     router.push("/signup/step3")
   }
 
   return (
-    <form className="flex flex-1 flex-col">
+    <form className="flex flex-1 flex-col gap-10">
       <Input
         name="password"
         type="password"
@@ -62,44 +61,28 @@ const Step2Form = () => {
         placeholder="비밀번호 입력"
         isFullWidth
         size="lg"
+        validations={passwordValidations}
+        onValidationChange={setIsPasswordValid}
       />
-      <div className="flex gap-5">
-        {[
-          { value: "alphabet", label: "영문포함" },
-          { value: "number", label: "숫자포함" },
-          { value: "length", label: "8자~20자" },
-        ].map(({ value, label }) => (
-          <ValidationItem
-            key={value}
-            isValid={validation[value as keyof typeof validation]}
-            label={label}
-          />
-        ))}
-      </div>
 
-      <Input
-        name="passwordConfirm"
-        type="password"
-        value={formData.passwordConfirm}
-        onChange={handleChange}
-        placeholder="비밀번호 확인"
-        className="mt-10"
-        isFullWidth
-        size="lg"
-      />
-      {formData.passwordConfirm && (
-        <ValidationItem
-          isValid={validation.match}
-          label="비밀번호 일치"
-          className="mt-2"
+      <div className="flex flex-col">
+        <Input
+          name="passwordConfirm"
+          type="password"
+          value={formData.passwordConfirm}
+          onChange={handleChange}
+          placeholder="비밀번호 확인"
+          isFullWidth
+          size="lg"
         />
-      )}
+        <ValidationItem isValid={isPasswordMatch} label="비밀번호 일치" />
+      </div>
 
       <Button
         type="button"
         size="lg"
-        disabled={!validation.passwordSuccess}
-        variant={!validation.passwordSuccess ? "disable" : "primary"}
+        disabled={!isPasswordValid || !isPasswordMatch}
+        variant={!isPasswordValid || !isPasswordMatch ? "disable" : "primary"}
         onClick={handleNext}
         className="mt-auto mb-6"
         isFullWidth

--- a/app/signup/[steps]/components/Step2Form.tsx
+++ b/app/signup/[steps]/components/Step2Form.tsx
@@ -6,21 +6,7 @@ import ValidationItem from "./ValidationItem"
 import { S1 } from "@/ds/components/atoms/text/TextWrapper"
 import { useSignupStore } from "@/hooks/useSignupStore"
 import { ValidatePassword } from "@/app/signup/[steps]/types"
-
-const passwordValidations = [
-  {
-    label: "영문포함",
-    validate: (value: string) => /[a-zA-Z]/.test(value),
-  },
-  {
-    label: "숫자포함",
-    validate: (value: string) => /[0-9]/.test(value),
-  },
-  {
-    label: "8자~20자",
-    validate: (value: string) => value.length >= 8 && value.length <= 20,
-  },
-]
+import { passwordValidations } from "@/utils/validation"
 
 const Step2Form = () => {
   const router = useRouter()

--- a/app/signup/[steps]/components/Step3Form.tsx
+++ b/app/signup/[steps]/components/Step3Form.tsx
@@ -8,18 +8,7 @@ import { SignupData, Gender } from "@/app/signup/[steps]/types"
 import { Button } from "@/ds/components/atoms/button/Button"
 import { S1 } from "@/ds/components/atoms/text/TextWrapper"
 import { useSignupStore } from "@/hooks/useSignupStore"
-
-const nicknameValidations = [
-  {
-    label: "20자 이하",
-    validate: (value: string) => value.length >= 1 && value.length <= 20,
-  },
-  {
-    label: "특수문자 제외",
-    validate: (value: string) =>
-      !/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(value),
-  },
-]
+import { nicknameValidations } from "@/utils/validation"
 
 const Step3Form = () => {
   const { data } = useSignupStore()

--- a/app/signup/[steps]/components/Step3Form.tsx
+++ b/app/signup/[steps]/components/Step3Form.tsx
@@ -5,10 +5,21 @@ import { signIn } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { ChangeEvent, useState, useTransition } from "react"
 import { SignupData, Gender } from "@/app/signup/[steps]/types"
-import ValidationItem from "./ValidationItem"
 import { Button } from "@/ds/components/atoms/button/Button"
 import { S1 } from "@/ds/components/atoms/text/TextWrapper"
 import { useSignupStore } from "@/hooks/useSignupStore"
+
+const nicknameValidations = [
+  {
+    label: "20자 이하",
+    validate: (value: string) => value.length >= 1 && value.length <= 20,
+  },
+  {
+    label: "특수문자 제외",
+    validate: (value: string) =>
+      !/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(value),
+  },
+]
 
 const Step3Form = () => {
   const { data } = useSignupStore()
@@ -24,31 +35,11 @@ const Step3Form = () => {
     gender: undefined as Gender | undefined,
     age: "",
   })
-  const [validation, setValidation] = useState({
-    length: false,
-    simpleText: true,
-    infoSuccess: false,
-  })
-
-  const validateCheck = (value: string) => {
-    const length = value.length >= 1 && value.length <= 20
-    const simpleText = !/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(value)
-    const infoSuccess = length && simpleText
-
-    return {
-      length,
-      simpleText,
-      infoSuccess,
-    }
-  }
+  const [isNicknameValid, setIsNicknameValid] = useState(false)
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     setFormData({ ...formData, [name]: value })
-    if (name === "nickname") {
-      const result = validateCheck(value)
-      setValidation(result)
-    }
   }
 
   const handleDropdownChange = (name: string) => (value: string | number) => {
@@ -89,7 +80,7 @@ const Step3Form = () => {
         setTimeout(() => {
           router.push("/")
         }, 1500)
-      } catch (error) {
+      } catch {
         showToast({
           message: "회원가입 실패 😢 다시 확인해주세요",
           variant: "error",
@@ -101,24 +92,17 @@ const Step3Form = () => {
   return (
     <form action={() => formAction(formData)} className="flex h-full flex-col">
       <div className="flex flex-1 flex-col gap-10">
-        <div className="flex flex-col">
-          <Input
-            name="nickname"
-            value={formData.nickname}
-            onChange={handleChange}
-            placeholder="닉네임"
-            isFullWidth
-            size="lg"
-            readOnly={isReadOlny}
-          />
-          <div className="flex gap-5">
-            <ValidationItem label="20자 이하" isValid={validation.length} />
-            <ValidationItem
-              label="특수문자 제외"
-              isValid={validation.simpleText}
-            />
-          </div>
-        </div>
+        <Input
+          name="nickname"
+          value={formData.nickname}
+          onChange={handleChange}
+          placeholder="닉네임"
+          isFullWidth
+          size="lg"
+          readOnly={isReadOlny}
+          validations={nicknameValidations}
+          onValidationChange={setIsNicknameValid}
+        />
         <Input
           name="height"
           type="number"
@@ -169,8 +153,8 @@ const Step3Form = () => {
         isFullWidth
         size="lg"
         className="mb-6"
-        disabled={isPending || !validation.infoSuccess}
-        variant={isPending || !validation.infoSuccess ? "disable" : "primary"}
+        disabled={isPending || !isNicknameValid}
+        variant={isPending || !isNicknameValid ? "disable" : "primary"}
       >
         <S1 variant="white-200">{isPending ? "처리 중..." : "회원가입"}</S1>
       </Button>

--- a/app/user/components/PasswordCheckModal.tsx
+++ b/app/user/components/PasswordCheckModal.tsx
@@ -7,11 +7,9 @@ import { Input } from "@/ds/components/atoms/input/Input"
 import React, { useState } from "react"
 import { Button } from "@/ds/components/atoms/button/Button"
 import { useCheckPassword } from "@/hooks/useCheckPassword"
-import Icon from "@/ds/components/atoms/icon/Icon"
 
 const PasswordCheckModal = ({ setIsAuth }: PasswordCheckModalProps) => {
   const [password, setPassword] = useState<string | undefined>("")
-  const [isOpenPassword, setIsOpenPassword] = useState<boolean>(false)
   const { mutate } = useCheckPassword({
     checkValid: () => setIsAuth(true),
   })
@@ -27,12 +25,12 @@ const PasswordCheckModal = ({ setIsAuth }: PasswordCheckModalProps) => {
   return (
     <div
       id="password-check-container"
-      className="relative flex h-[300px] w-full flex-col border-x-2 border-t-2 border-(--color-primary) bg-(--color-white-200) p-5"
+      className="flex h-[300px] w-full flex-col border-x-2 border-t-2 border-(--color-primary) bg-(--color-white-200) p-5"
     >
       <S1>비밀번호 확인</S1>
       <div className="relative mt-6 flex flex-col gap-[20px]">
         <Input
-          type={isOpenPassword ? "text" : "password"}
+          type="password"
           value={password}
           size={"lg"}
           className="text-primary"
@@ -42,16 +40,6 @@ const PasswordCheckModal = ({ setIsAuth }: PasswordCheckModalProps) => {
             setPassword(e.target.value)
           }}
         />
-        <Button
-          size="xs"
-          variant="ghost"
-          className="absolute top-1/2 right-0 -translate-y-1/2"
-          onClick={() => {
-            setIsOpenPassword((prev) => !prev)
-          }}
-        >
-          <Icon name={isOpenPassword ? "eyeCrossed" : "eye"} />
-        </Button>
       </div>
       <div className="mt-4 flex justify-end">
         <Button size="sm" onClick={checkPassword}>

--- a/app/user/components/PasswordCheckModal.tsx
+++ b/app/user/components/PasswordCheckModal.tsx
@@ -27,20 +27,18 @@ const PasswordCheckModal = ({ setIsAuth }: PasswordCheckModalProps) => {
       id="password-check-container"
       className="flex h-[300px] w-full flex-col border-x-2 border-t-2 border-(--color-primary) bg-(--color-white-200) p-5"
     >
-      <S1>비밀번호 확인</S1>
-      <div className="relative mt-6 flex flex-col gap-[20px]">
-        <Input
-          type="password"
-          value={password}
-          size={"lg"}
-          className="text-primary"
-          isFullWidth={true}
-          placeholder="기존 비밀번호를 입력하세요"
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setPassword(e.target.value)
-          }}
-        />
-      </div>
+      <S1 className="mb-6">비밀번호 확인</S1>
+      <Input
+        type="password"
+        value={password}
+        size={"lg"}
+        className="text-primary"
+        isFullWidth={true}
+        placeholder="기존 비밀번호를 입력하세요"
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setPassword(e.target.value)
+        }}
+      />
       <div className="mt-4 flex justify-end">
         <Button size="sm" onClick={checkPassword}>
           Click me!

--- a/app/user/components/PasswordInput.tsx
+++ b/app/user/components/PasswordInput.tsx
@@ -2,21 +2,7 @@ import { Input } from "@/ds/components/atoms/input/Input"
 import { ChangeEvent, useEffect, useState } from "react"
 import { PasswordInputProps } from "@/app/user/types"
 import ValidationItem from "@/app/signup/[steps]/components/ValidationItem"
-
-const passwordValidations = [
-  {
-    label: "영문포함",
-    validate: (value: string) => /[a-zA-Z]/.test(value),
-  },
-  {
-    label: "숫자포함",
-    validate: (value: string) => /[0-9]/.test(value),
-  },
-  {
-    label: "8자~20자",
-    validate: (value: string) => value.length >= 8 && value.length <= 20,
-  },
-]
+import { passwordValidations } from "@/utils/validation"
 
 const PasswordInput = ({ password, setPassword }: PasswordInputProps) => {
   const [isPasswordValid, setIsPasswordValid] = useState(false)

--- a/app/user/components/PasswordInput.tsx
+++ b/app/user/components/PasswordInput.tsx
@@ -1,69 +1,59 @@
 import { Input } from "@/ds/components/atoms/input/Input"
 import { ChangeEvent, useEffect, useState } from "react"
-import { Password, PasswordInputProps } from "@/app/user/types"
+import { PasswordInputProps } from "@/app/user/types"
 import ValidationItem from "@/app/signup/[steps]/components/ValidationItem"
 
+const passwordValidations = [
+  {
+    label: "영문포함",
+    validate: (value: string) => /[a-zA-Z]/.test(value),
+  },
+  {
+    label: "숫자포함",
+    validate: (value: string) => /[0-9]/.test(value),
+  },
+  {
+    label: "8자~20자",
+    validate: (value: string) => value.length >= 8 && value.length <= 20,
+  },
+]
+
 const PasswordInput = ({ password, setPassword }: PasswordInputProps) => {
-  const [validation, setValidation] = useState({
-    alphabet: false,
-    number: false,
-    length: false,
-    match: false,
-    passwordSuccess: false,
-  })
-
-  const validateCheck = (password: string, passwordConfirm: string) => {
-    const alphabet = /[a-zA-Z]/.test(password)
-    const number = /[0-9]/.test(password)
-    const length = password.length >= 8 && password.length <= 20
-    const match = password === passwordConfirm && password !== ""
-    const passwordSuccess = alphabet && number && length && match
-
-    return { alphabet, number, length, match, passwordSuccess }
-  }
+  const [isPasswordValid, setIsPasswordValid] = useState(false)
+  const [isPasswordMatch, setIsPasswordMatch] = useState(false)
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    setPassword({ ...password, [name]: value })
+    const nextPassword = { ...password, [name]: value }
+    setPassword(nextPassword)
 
-    const result = validateCheck(
-      name === "password" ? value : password.password,
-      name === "passwordConfirm" ? value : password.passwordConfirm
-    )
-    setValidation(result)
+    if (name === "passwordConfirm" || name === "password") {
+      setIsPasswordMatch(
+        nextPassword.passwordConfirm !== "" &&
+          nextPassword.password !== "" &&
+          nextPassword.passwordConfirm === nextPassword.password
+      )
+    }
   }
 
   useEffect(() => {
-    setPassword({ ...password, validate: validation.passwordSuccess })
-  }, [validation])
+    setPassword({ ...password, validate: isPasswordValid && isPasswordMatch })
+  }, [isPasswordValid, isPasswordMatch])
 
   return (
     <>
-      <div className="flex flex-col gap-0.5">
-        <Input
-          name="password"
-          type="password"
-          value={password.password}
-          size={"lg"}
-          className={"text-primary"}
-          isFullWidth={true}
-          placeholder={"새로운 비밀번호를 입력하세요"}
-          onChange={handleChange}
-        />
-        <div className="flex gap-5">
-          {[
-            { value: "alphabet", label: "영문포함" },
-            { value: "number", label: "숫자포함" },
-            { value: "length", label: "8자~20자" },
-          ].map(({ value, label }) => (
-            <ValidationItem
-              key={value}
-              isValid={validation[value as keyof typeof validation]}
-              label={label}
-            />
-          ))}
-        </div>
-      </div>
+      <Input
+        name="password"
+        type="password"
+        value={password.password}
+        size={"lg"}
+        className={"text-primary"}
+        isFullWidth={true}
+        placeholder={"새로운 비밀번호를 입력하세요"}
+        onChange={handleChange}
+        validations={passwordValidations}
+        onValidationChange={setIsPasswordValid}
+      />
       <div className="flex flex-col gap-0.5">
         <Input
           name="passwordConfirm"
@@ -75,9 +65,7 @@ const PasswordInput = ({ password, setPassword }: PasswordInputProps) => {
           isFullWidth
           size="lg"
         />
-        <div className="flex">
-          <ValidationItem isValid={validation.match} label="비밀번호 일치" />
-        </div>
+        <ValidationItem isValid={isPasswordMatch} label="비밀번호 일치" />
       </div>
     </>
   )

--- a/ds/components/atoms/input/Input.tsx
+++ b/ds/components/atoms/input/Input.tsx
@@ -17,6 +17,7 @@ export const Input: React.FC<InputProps> = ({
   readOnly = false,
   className,
   onChange,
+  onValidationChange,
   ...props
 }) => {
   const [validationFeedback, setValidationFeedback] = useState<boolean[]>([])
@@ -31,6 +32,15 @@ export const Input: React.FC<InputProps> = ({
 
     const validationResults = validations.map((rule) => rule.validate(value))
     setValidationFeedback(validationResults)
+
+    if (onValidationChange) {
+      const isValid =
+        validationResults.length > 0
+          ? validationResults.every((result) => result === true)
+          : true
+      const hasError = !!matchedError
+      onValidationChange(isValid && !hasError)
+    }
 
     onChange?.(e)
   }

--- a/ds/components/atoms/input/Input.tsx
+++ b/ds/components/atoms/input/Input.tsx
@@ -71,7 +71,7 @@ export const Input: React.FC<InputProps> = ({
           type="button"
           size="xs"
           variant="ghost"
-          className="absolute top-1/2 right-0 -translate-y-1/2"
+          className="absolute top-0 right-0"
           onClick={() => {
             setIsOpenPassword((prev) => !prev)
           }}

--- a/ds/components/atoms/input/Input.tsx
+++ b/ds/components/atoms/input/Input.tsx
@@ -5,6 +5,7 @@ import { InputProps } from "./Input.types"
 import { inputSizes } from "@/ds/styles/tokens/input/sizes"
 import { C2 } from "../text/TextWrapper"
 import Icon from "../icon/Icon"
+import { Button } from "../button/Button"
 
 export const Input: React.FC<InputProps> = ({
   type = "text",
@@ -20,6 +21,7 @@ export const Input: React.FC<InputProps> = ({
 }) => {
   const [validationFeedback, setValidationFeedback] = useState<boolean[]>([])
   const [errorMessage, setErrorMessage] = useState<string>("")
+  const [isOpenPassword, setIsOpenPassword] = useState<boolean>(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -34,7 +36,7 @@ export const Input: React.FC<InputProps> = ({
   }
 
   const combinedClassName = `
-    border-b-1 border-[var(--color-secondary)] outline-none font-[var(--color-secondary)]
+    border-b-1 border-[var(--color-secondary)] outline-none font-[var(--color-secondary)] relative
     ${inputSizes[size]}
     ${isFullWidth ? "w-full" : ""}
     ${readOnly ? "cursor-default" : ""}
@@ -42,15 +44,31 @@ export const Input: React.FC<InputProps> = ({
   `.trim()
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="relative flex flex-col gap-1">
       <input
-        type={type}
+        type={
+          type === "password" ? (isOpenPassword ? "text" : "password") : type
+        }
         placeholder={placeholder}
         className={combinedClassName}
         onChange={handleChange}
         readOnly={readOnly}
         {...props}
       />
+
+      {type === "password" && (
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          className="absolute top-1/2 right-0 -translate-y-1/2"
+          onClick={() => {
+            setIsOpenPassword((prev) => !prev)
+          }}
+        >
+          <Icon name={isOpenPassword ? "eyeCrossed" : "eye"} />
+        </Button>
+      )}
 
       {/* Error message */}
       {errorMessage && <C2 variant="error">{errorMessage}</C2>}
@@ -59,11 +77,8 @@ export const Input: React.FC<InputProps> = ({
       {validations.length > 0 && (
         <div className="flex flex-wrap gap-5">
           {validations.map((rule, idx) => (
-            <div className="flex flex-wrap items-center gap-[5px]">
-              <C2
-                key={idx}
-                variant={validationFeedback[idx] ? "success" : "disable"}
-              >
+            <div key={idx} className="flex flex-wrap items-center gap-[5px]">
+              <C2 variant={validationFeedback[idx] ? "success" : "disable"}>
                 {rule.label}
               </C2>
               <Icon

--- a/ds/components/atoms/input/Input.types.ts
+++ b/ds/components/atoms/input/Input.types.ts
@@ -18,4 +18,5 @@ export interface InputProps
   placeholder?: string
   validations?: ValidationRule[]
   errorRules?: ErrorRule[]
+  onValidationChange?: (isValid: boolean) => void
 }

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,0 +1,39 @@
+export const emailErrorRules = [
+  {
+    when: (value: string) => value.trim() === "",
+    message: "이메일을 입력해주세요",
+  },
+  {
+    when: (value: string) =>
+      value.length > 0 &&
+      !/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value),
+    message: "올바른 이메일 형식이 아닙니다",
+  },
+]
+
+export const passwordValidations = [
+  {
+    label: "영문포함",
+    validate: (value: string) => /[a-zA-Z]/.test(value),
+  },
+  {
+    label: "숫자포함",
+    validate: (value: string) => /[0-9]/.test(value),
+  },
+  {
+    label: "8자~20자",
+    validate: (value: string) => value.length >= 8 && value.length <= 20,
+  },
+]
+
+export const nicknameValidations = [
+  {
+    label: "20자 이하",
+    validate: (value: string) => value.length >= 1 && value.length <= 20,
+  },
+  {
+    label: "특수문자 제외",
+    validate: (value: string) =>
+      !/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?`~]/.test(value),
+  },
+]


### PR DESCRIPTION
## 🔍 개요 (Overview)
Input 컴포넌트에 비밀번호 토글 버튼을 추가하고, 
각 컴포넌트에서 직접 확인하던 검증 로직을 Input의 validation/error 기능 사용하도록 수정했습니다.

(예: Closes #314 )


## ✅ 작업 사항 (Work Done)

- [x] Input 컴포넌트에 비밀번호 보기/숨기기 토글 버튼 추가
- [x] Input 검증 결과 전달 기능 추가
- [x] 각 컴포넌트에서 처리하던 이메일/비밀번호/닉네임 검증 로직 Input의 validation/error 기능으로 통합


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :----:  |
|        |  <img width="385" height="721" alt="스크린샷 2026-01-28 오후 6 55 50" src="https://github.com/user-attachments/assets/54ad0924-e223-4b7d-a92b-548390b19dfb" />     |


##  reviewers에게

비밀번호 일치 검증은 여전히 각 컴포넌트에서 처리하고 있는데요
현재 Input 컴포넌트의 validation, error 로직은 onChange 시점에 자기 자신의 값 변경에 의해서만 실행되는 구조입니다.
password 변경 시 passwordConfirm 검증을 트리거하기 위해 이것저것 손대보았으나 지식의 한계를 느끼고.. 비밀번호 일치 검증은 각 상위 컴포넌트에서 별도로 처리하는 것으로 마무리 했습니다. 🥲