### PR TITLE
fix: #339 운동 기록 저장 후 store 초기화

### DIFF
--- a/hooks/useCreateUserLogs.ts
+++ b/hooks/useCreateUserLogs.ts
@@ -5,14 +5,18 @@ import {
 } from "@/services/user/logs/createUserLogs"
 import { useToastStore } from "@/hooks/useToastStore"
 import { useRouter } from "next/navigation"
+import { useExerciseLogStore } from "@/hooks/useExerciseLogStore"
 
 export const useCreateUserLogs = () => {
   const { showToast } = useToastStore()
   const router = useRouter()
+  const { setInit } = useExerciseLogStore()
 
   return useMutation({
     mutationFn: (data: CreateLogRequest) => createUserLogs(data),
     onSuccess: (response) => {
+      setInit()
+
       if (response.awardedBadges && response.awardedBadges.length > 0) {
         router.push("/")
         showToast({


### PR DESCRIPTION
## 🔍 개요 (Overview)
운동 기록 저장 후 폼 데이터 초기화 되지 않는 문제 해결
(예: Closes #339 )

## ✅ 작업 사항 (Work Done)
- [x] 운동 기록 저장 성공 시, store에 있는 폼 데이터 초기화

## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
| ![20260131-2307-15 8803522](https://github.com/user-attachments/assets/02d3df79-ca2a-47b5-90e7-c24c054233a6) | ![20260131-2311-17 0752716](https://github.com/user-attachments/assets/a28a2c95-c590-40b0-9cfc-6bcba837a41e) |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
