### PR TITLE
[Refactor] email check 페이지 공통 컴포넌트 적용

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -20,6 +20,20 @@ export const PASSWORD_CONFIRM_VALIDATION_LABEL: PasswordValidationRuleLabel[] =
   [{ label: "비밀번호 일치", value: "match" }]
 
 /**
+ * for email validation
+ * usage: app/signup/[steps]/components/Step1Form.tsx
+ */
+interface EmailValidationRuleLabel {
+  label: string
+  value: "hasValue" | "validFormat"
+}
+
+export const EMAIL_VALIDATION_LABELS: EmailValidationRuleLabel[] = [
+  { label: "아이디 입력", value: "hasValue" },
+  { label: "이메일 형식", value: "validFormat" },
+]
+
+/**
  * for user info validation
  * usage:
  *    app/signup/[step]/components/Step3Form.tsx

--- a/app/signup/[steps]/components/Step1Form.tsx
+++ b/app/signup/[steps]/components/Step1Form.tsx
@@ -1,102 +1,86 @@
 import { Button } from "@/ds/components/atoms/button/Button"
-import { Input } from "@/ds/components/atoms/input/Input"
-import { C2, S1 } from "@/ds/components/atoms/text/TextWrapper"
+import ValidationCheck from "@/ds/components/atoms/validationCheck/ValidationCheck"
+import { S1 } from "@/ds/components/atoms/text/TextWrapper"
+import InputWithValidation from "@/ds/components/molecules/inputWithValidation/InputWithValidation"
 import { checkEmail } from "@/services/user/checkEmail"
 import { useRouter } from "next/navigation"
-import { ChangeEvent, useState, useTransition } from "react"
+import { useTransition } from "react"
 
 import { useSignupStore } from "@/hooks/useSignupStore"
+import { useEmailValidation } from "@/hooks/useEmailValidation"
 import { SignupData } from "@/app/signup/[steps]/types"
+import { EMAIL_VALIDATION_LABELS } from "@/app/constants"
 
 function Step1Form() {
   const router = useRouter()
   const { set1Data } = useSignupStore()
-
   const [isPending, startTransition] = useTransition()
-  const [formData, setFormData] = useState({ email: "" })
-  const [validation, setValidation] = useState({
-    emailError: "",
-    emailSuccess: false,
-  })
 
-  const validateCheck = (email: string) => {
-    if (!email) return "아이디를 입력해주세요"
-    else if (!/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email)) {
-      return "올바른 이메일 형식이 아닙니다"
-    }
-  }
+  const {
+    formData,
+    validation,
+    handleChange,
+    checkResult,
+    setCheckResult,
+    emailFormatSuccess,
+  } = useEmailValidation()
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    const formatError = validateCheck(value)
-
-    setFormData({ email: value })
-
-    if (formatError) {
-      setValidation({ emailError: formatError, emailSuccess: false })
-    } else {
-      setValidation({ emailError: "", emailSuccess: false })
-    }
-  }
+  const emailValidations = EMAIL_VALIDATION_LABELS.map((item) => ({
+    label: item.label,
+    isValid: validation[item.value],
+  }))
 
   const formAction = (formData: SignupData["step1"]) => {
     startTransition(async () => {
       if (!formData.email) return
 
       const result = await checkEmail(formData.email)
-
-      if (result.isAvailable) {
-        setValidation({ emailError: "", emailSuccess: true })
-      } else {
-        setValidation({
-          emailError: result.message,
-          emailSuccess: false,
-        })
-      }
+      setCheckResult({
+        message: result.message,
+        isAvailable: result.isAvailable,
+      })
     })
   }
 
   const handleNext = () => {
-    if (!validation.emailSuccess || !formData.email) return
-
+    if (!checkResult?.isAvailable || !formData.email) return
     set1Data({ email: formData.email })
     router.push("/signup/step2")
   }
 
+  console.log(formData)
   return (
     <form action={() => formAction(formData)} className="flex flex-1 flex-col">
-      <Input
+      <InputWithValidation
         name="email"
         value={formData.email}
         onChange={handleChange}
-        placeholder="아이디를 입력"
+        placeholder="아이디를 입력 해주세요"
         isFullWidth
         size="lg"
+        validations={emailValidations}
       />
-      {validation.emailError && (
-        <C2 variant="error" className="mt-[5px]">
-          {validation.emailError}
-        </C2>
-      )}
-      {!validation.emailError && validation.emailSuccess && (
-        <C2 variant="success" className="mt-[5px]">
-          사용 가능한 이메일입니다.
-        </C2>
+      {checkResult && (
+        <ValidationCheck
+          label={checkResult.message}
+          variant={checkResult.isAvailable ? "success" : "error"}
+          showIcon={false}
+        />
       )}
 
       <Button
         isFullWidth
         size="lg"
         className="mt-auto mb-6"
-        disabled={isPending || !!validation.emailError}
-        variant={validation.emailError ? "disable" : "primary"}
-        type={validation.emailSuccess ? "button" : "submit"}
+        disabled={isPending || !emailFormatSuccess}
+        variant={!emailFormatSuccess ? "disable" : "primary"}
+        type={checkResult?.isAvailable ? "button" : "submit"}
         onClick={handleNext}
       >
         <S1 variant="white-200">
           {isPending
             ? "중복확인 중..."
-            : validation.emailSuccess
+            : checkResult?.isAvailable
               ? "다음"
               : "중복확인"}
         </S1>

--- a/ds/components/atoms/validationCheck/ValidationCheck.tsx
+++ b/ds/components/atoms/validationCheck/ValidationCheck.tsx
@@ -3,21 +3,21 @@ import { C2 } from "@/ds/components/atoms/text/TextWrapper"
 import Icon from "@/ds/components/atoms/icon/Icon"
 
 const ValidationCheck = ({
-  isValid,
   label,
+  variant,
   showIcon = true,
   className,
 }: ValidationCheckProps) => {
-  const customClassName = `flex items-end gap-2 ${className}`
+  if (!label) return null
+
+  const customClassName = `flex items-end gap-2 ${className ?? ""}`.trim()
 
   return (
     <div className={customClassName}>
-      <C2 variant={isValid ? "success" : "disable"} className="mt-[5px]">
+      <C2 variant={variant} className="mt-[5px]">
         {label}
       </C2>
-      {showIcon && (
-        <Icon name="check" size={10} color={isValid ? "success" : "disable"} />
-      )}
+      {showIcon && <Icon name="check" size={10} color={variant} />}
     </div>
   )
 }

--- a/ds/components/atoms/validationCheck/ValidationCheckProps.types.ts
+++ b/ds/components/atoms/validationCheck/ValidationCheckProps.types.ts
@@ -1,8 +1,10 @@
 import { HTMLAttributes } from "react"
 
+export type ValidationCheckVariant = "success" | "error" | "disable"
+
 export interface ValidationCheckProps {
-  isValid: boolean
-  label: string
+  label?: string
+  variant: ValidationCheckVariant
   showIcon?: boolean
   className?: HTMLAttributes<HTMLDivElement>["className"]
 }

--- a/ds/components/molecules/inputWithValidation/InputWithValidation.tsx
+++ b/ds/components/molecules/inputWithValidation/InputWithValidation.tsx
@@ -32,8 +32,8 @@ const InputWithValidation = ({
         {validations.map(({ label, isValid }) => (
           <ValidationCheck
             key={`${label}_check`}
-            isValid={isValid}
             label={label}
+            variant={isValid ? "success" : "disable"}
           />
         ))}
       </div>

--- a/ds/components/molecules/inputWithValidation/InputWithValidation.tsx
+++ b/ds/components/molecules/inputWithValidation/InputWithValidation.tsx
@@ -21,6 +21,7 @@ const InputWithValidation = ({
         name={name}
         type={type}
         size={size}
+        value={value}
         isFullWidth={isFullWidth}
         placeholder={placeholder}
         readOnly={readOnly}

--- a/hooks/useEmailValidation.ts
+++ b/hooks/useEmailValidation.ts
@@ -1,0 +1,49 @@
+import { useState, ChangeEvent } from "react"
+
+export interface EmailValidationState {
+  hasValue: boolean
+  validFormat: boolean
+  emailFormatSuccess: boolean
+}
+
+export interface EmailCheckResult {
+  message: string
+  isAvailable: boolean
+}
+
+const validateCheck = (email: string): EmailValidationState => {
+  const hasValue = email.trim().length > 0
+  const validFormat = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(
+    email
+  )
+  const emailFormatSuccess = hasValue && validFormat
+
+  return { hasValue, validFormat, emailFormatSuccess }
+}
+
+export const useEmailValidation = () => {
+  const [formData, setFormData] = useState({ email: "" })
+  const [validation, setValidation] = useState<EmailValidationState>({
+    hasValue: false,
+    validFormat: false,
+    emailFormatSuccess: false,
+  })
+  const [checkResult, setCheckResult] = useState<EmailCheckResult | null>(null)
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setFormData({ email: value })
+    const result = validateCheck(value)
+    setValidation(result)
+    setCheckResult(null)
+  }
+
+  return {
+    formData,
+    validation,
+    handleChange,
+    checkResult,
+    setCheckResult,
+    emailFormatSuccess: validation.emailFormatSuccess,
+  }
+}


### PR DESCRIPTION
## 🔍 개요 (Overview)

email check 페이지 공통 컴포넌트 적용
(예: Closes #344 )


## ✅ 작업 사항 (Work Done)

- [ ] email check에  InputWithValidation 컴포넌트 재사용으로 적용
- [ ] validationcheck 컴포넌트 error variant도 사용가능하도록 수정


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
|        |       |


##  reviewers에게

- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요.
- 궁금한 점이나 논의가 필요한 부분도 좋습니다.
