### PR TITLE
[QA] #347 Safari 환경에서 RangeError: Invalid time value 발생 문제

### DIFF
--- a/app/logs/components/DatePicker.tsx
+++ b/app/logs/components/DatePicker.tsx
@@ -5,6 +5,8 @@ import "react-datepicker/dist/react-datepicker.css"
 import dayjs from "dayjs"
 import Icon from "@/ds/components/atoms/icon/Icon"
 import { useExerciseLogStore } from "@/hooks/useExerciseLogStore"
+import customParseFormat from "dayjs/plugin/customParseFormat";
+dayjs.extend(customParseFormat);
 
 const CustomDatePicker = () => {
   const { date, setDate } = useExerciseLogStore()


### PR DESCRIPTION
## 🔍 개요 (Overview)
Safari 환경에서 운동 기록 페이지 접근 시 `invalid time value` 에러가 발생하는 이슈를 수정
- `dayjs` 플러그인을 등록하지 않은 상태에서 dayjs 함수를 사용해 `.`이 들어간 커스텀 날짜 포맷을 사용해 발생한 문제
-  Chrome에서는 날짜 value의 `.` 구분자를 관대하게 파싱하는 반면, Safari에서는 허용하지 않기 때문에 safari환경에서만 발생한 이슈
( Closes #347 )


## ✅ 작업 사항 (Work Done)
- [x] dayjs customParseFormat 플러그인 적용


## 📸 스크린샷 (Screenshots)

| Before | After |
| :----: | :---: |
| <img width="934" height="384" alt="image" src="https://github.com/user-attachments/assets/303a28ee-eb20-40e5-9f0c-e480c49169b4" /><img width="230" height="36" alt="image" src="https://github.com/user-attachments/assets/0239a34b-c367-458a-8d5b-e51166d6c4d2" /> | 에러 없음! |


##  reviewers에게

